### PR TITLE
Rewrite the usage of wayland-client code

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -27,7 +27,9 @@ pub async fn run() -> Result<()> {
                     )?;
                 }
                 Action::Close(Some(id)) => {
-                    dbg!(id);
+                    server_internal_channel.send_to_renderer(
+                        crate::data::internal_messages::ServerMessage::CloseNotification { id },
+                    )?;
                 }
                 Action::Close(None) => {
                     dbg!("close last");

--- a/src/core.rs
+++ b/src/core.rs
@@ -10,7 +10,7 @@ use crate::{
 
 pub async fn run() -> Result<()> {
     let (sender, mut receiver) = unbounded_channel();
-    let _server = Server::init(sender).await?;
+    let server = Server::init(sender).await?;
 
     let (server_internal_channel, mut renderer) = Renderer::init()?;
 
@@ -40,6 +40,32 @@ pub async fn run() -> Result<()> {
                 Action::CloseAll => {
                     todo!("show all");
                 }
+            }
+        }
+
+        while let Ok(message) = server_internal_channel.try_recv_from_renderer() {
+            match message {
+                //TODO: add actions for notifications in render module
+                #[allow(unused)]
+                crate::data::internal_messages::RendererMessage::ActionInvoked {
+                    notification_id,
+                    action_key,
+                } => todo!(),
+                crate::data::internal_messages::RendererMessage::ClosedNotification {
+                    id,
+                    reason,
+                } => match reason {
+                    //INFO: ignore the first one because it always emits in server.
+                    crate::data::dbus::ClosingReason::CallCloseNotification => (),
+                    other_reason => {
+                        server
+                            .emit_signal(crate::data::dbus::Signal::NotificationClosed {
+                                notification_id: id,
+                                reason: other_reason,
+                            })
+                            .await?;
+                    }
+                },
             }
         }
 

--- a/src/data/dbus.rs
+++ b/src/data/dbus.rs
@@ -20,7 +20,7 @@ pub enum Signal {
 
 pub enum ClosingReason {
     Expired,
-    DimissedByUser,
+    DismissedByUser,
     CallCloseNotification,
     Undefined,
 }
@@ -29,7 +29,7 @@ impl From<ClosingReason> for u32 {
     fn from(value: ClosingReason) -> Self {
         match value {
             ClosingReason::Expired => 1,
-            ClosingReason::DimissedByUser => 2,
+            ClosingReason::DismissedByUser => 2,
             ClosingReason::CallCloseNotification => 3,
             ClosingReason::Undefined => 4,
         }

--- a/src/data/notification.rs
+++ b/src/data/notification.rs
@@ -201,8 +201,8 @@ impl From<i32> for Timeout {
     fn from(value: i32) -> Self {
         match value {
             t if t < -1 => todo!(),
-            -1 => Self::Never,
-            0 => Self::Configurable,
+            0 => Self::Never,
+            -1 => Self::Configurable,
             t => Self::Millis(t as u32),
         }
     }

--- a/src/dbus/server.rs
+++ b/src/dbus/server.rs
@@ -75,12 +75,12 @@ impl Handler {
         expire_timeout: i32,
     ) -> Result<u32> {
         let id = match replaces_id {
-            0 => UNIQUE_ID.load(Ordering::Relaxed),
+            0 => UNIQUE_ID.fetch_add(1, Ordering::Relaxed),
             _ => replaces_id,
         };
 
         #[rustfmt::skip]
-        let created_at = SystemTime::now() .duration_since(UNIX_EPOCH) .unwrap() .as_secs();
+        let created_at = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
         let hints = Hints::from(&hints);
         let actions = NotificationAction::from_vec(&actions);
         let body = Text::parse(body);

--- a/src/render.rs
+++ b/src/render.rs
@@ -34,7 +34,6 @@ impl Renderer {
     }
 
     pub(crate) fn run(&mut self) {
-        let mut created = false;
         let mut notifications_to_create = vec![];
         let mut notifications_to_close = vec![];
 
@@ -53,16 +52,16 @@ impl Renderer {
 
             if !notifications_to_create.is_empty() {
                 self.notification_stack
-                    .create_notification_rects(notifications_to_create);
+                    .create_notifications(notifications_to_create);
                 notifications_to_create = vec![];
-                created = true;
             }
 
-            if !created && !notifications_to_close.is_empty() {
+            if !notifications_to_close.is_empty() {
                 self.notification_stack
                     .close_notifications(&notifications_to_close);
                 notifications_to_close.clear();
             }
+            self.notification_stack.remove_expired();
 
             while let Some(message) = self.notification_stack.pop_event() {
                 self.channel.send_to_server(message).unwrap();
@@ -71,7 +70,6 @@ impl Renderer {
             self.notification_stack.handle_actions();
             self.notification_stack.dispatch();
 
-            created = false;
             std::thread::sleep(Duration::from_millis(50));
             std::hint::spin_loop();
         }

--- a/src/render/layer.rs
+++ b/src/render/layer.rs
@@ -180,7 +180,7 @@ impl NotificationStack {
                     notifications.into_iter().for_each(|notification| {
                         self.events.push(RendererMessage::ClosedNotification {
                             id: notification.id,
-                            reason: crate::data::dbus::ClosingReason::DimissedByUser,
+                            reason: crate::data::dbus::ClosingReason::DismissedByUser,
                         })
                     })
                 }


### PR DESCRIPTION
Moved to single window instance with inner actions. Added possibility to dismiss notifications by left button click and by timeout if possible.

Also added possibility to close notifications by method `CloseNotification` from D-Bus.