### PR TITLE
refactor: use `ConfigProprety` derive macro for more pleasant config maintainment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "anyhow",
  "dbus",
  "inotify",
+ "macros",
  "once_cell",
  "serde",
  "toml",
@@ -1246,6 +1247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2005,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/backend",
   "crates/client",
   "crates/dbus",
+  "crates/macros",
 ]
 
 [workspace.package]

--- a/crates/backend/src/render/banner.rs
+++ b/crates/backend/src/render/banner.rs
@@ -1,6 +1,6 @@
-use std::{fs::File, io::Write, time};
+use std::time;
 
-use config::{spacing::Spacing, Alignment, Config, DisplayConfig, Position};
+use config::{spacing::Spacing, Config, DisplayConfig};
 use dbus::notification::Notification;
 
 use super::{
@@ -8,7 +8,9 @@ use super::{
     color::Bgra,
     font::FontCollection,
     types::RectSize,
-    widget::{self, ContainerBuilder, Coverage, Draw, DrawColor, WImage, WText},
+    widget::{
+        self, Alignment, ContainerBuilder, Coverage, Draw, DrawColor, Position, WImage, WText,
+    },
 };
 
 pub struct BannerRect {
@@ -54,22 +56,22 @@ impl BannerRect {
 
     pub(crate) fn draw(&mut self, font_collection: &FontCollection, config: &Config) {
         let rect_size = RectSize::new(
-            config.general().width() as usize,
-            config.general().height() as usize,
+            config.general().width as usize,
+            config.general().height as usize,
         );
 
         let display = config.display_by_app(&self.data.app_name);
-        let colors = display.colors().by_urgency(&self.data.hints.urgency);
+        let colors = display.colors.by_urgency(&self.data.hints.urgency);
 
-        let background: Bgra = colors.background().into();
+        let background: Bgra = Bgra::from(&colors.background);
 
         self.init_framebuffer(&rect_size, &background);
         self.stride = rect_size.width as usize * 4;
 
-        let border_spacing = Spacing::all_directional(display.border().size());
-        let padding = display.padding() + border_spacing;
+        let border_spacing = Spacing::all_directional(display.border.size);
+        let padding = &display.padding + border_spacing;
 
-        let font_size = config.general().font().size() as f32;
+        let font_size = config.general().font.size as f32;
 
         let mut container = ContainerBuilder::default()
             .spacing(padding)
@@ -98,8 +100,8 @@ impl BannerRect {
         });
 
         self.draw_border(
-            config.general().width().into(),
-            config.general().height().into(),
+            config.general().width.into(),
+            config.general().height.into(),
             &background,
             display,
         );
@@ -119,12 +121,12 @@ impl BannerRect {
         background: &Bgra,
         display: &DisplayConfig,
     ) {
-        let border_cfg = display.border();
+        let border_cfg = &display.border;
 
         let border = BorderBuilder::default()
-            .size(border_cfg.size() as usize)
-            .radius(border_cfg.radius() as usize)
-            .color(border_cfg.color().into())
+            .size(border_cfg.size as usize)
+            .radius(border_cfg.radius as usize)
+            .color(Bgra::from(&border_cfg.color))
             .background_color(background.clone())
             .frame_width(width as usize)
             .frame_height(height as usize)

--- a/crates/backend/src/render/color.rs
+++ b/crates/backend/src/render/color.rs
@@ -1,6 +1,6 @@
 use std::ops::{Mul, MulAssign};
 
-use config::Color;
+use config::colors::Color;
 
 use super::widget::Coverage;
 

--- a/crates/backend/src/render/font.rs
+++ b/crates/backend/src/render/font.rs
@@ -8,7 +8,7 @@ use std::{
     process::Command,
 };
 
-use config::TextStyle;
+use config::text::TextStyle;
 use dbus::text::EntityKind;
 
 use super::{

--- a/crates/backend/src/render/image.rs
+++ b/crates/backend/src/render/image.rs
@@ -48,14 +48,14 @@ impl Image {
                     image::DynamicImage::from(rgb_image)
                 };
 
-                Self::resize(&mut width, &mut height, image_property.max_size());
+                Self::resize(&mut width, &mut height, image_property.max_size);
                 let rowstride = width * 4;
 
                 let image = image::imageops::resize(
                     &image,
                     width as u32,
                     height as u32,
-                    image_property.resizing_method().to_filter_type(),
+                    image_property.resizing_method.to_filter_type(),
                 );
 
                 Image::Exists(ImageData {
@@ -164,7 +164,7 @@ impl Image {
             tree_size.height().round() as i32,
         );
 
-        Self::resize(&mut width, &mut height, image_property.max_size());
+        Self::resize(&mut width, &mut height, image_property.max_size);
 
         let scale = if width > height {
             width as f32 / tree_size.width()

--- a/crates/backend/src/render/text.rs
+++ b/crates/backend/src/render/text.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use derive_builder::Builder;
 use itertools::Itertools;
 
-use config::{spacing::Spacing, EllipsizeAt, TextJustification};
+use config::{spacing::Spacing, text::{EllipsizeAt, TextJustification}};
 use dbus::text::Text;
 
 use super::{

--- a/crates/backend/src/window.rs
+++ b/crates/backend/src/window.rs
@@ -62,8 +62,8 @@ impl Window {
             font_collection,
 
             rect_size: RectSize::new(
-                config.general().width().into(),
-                config.general().height().into(),
+                config.general().width.into(),
+                config.general().height.into(),
             ),
             margin: Margin::new(),
 
@@ -121,7 +121,7 @@ impl Window {
             (),
         ));
 
-        self.relocate(config.general().offset(), config.general().anchor());
+        self.relocate(config.general().offset, &config.general().anchor);
 
         {
             let layer_surface = unsafe { self.layer_surface.as_ref().unwrap_unchecked() };
@@ -135,9 +135,9 @@ impl Window {
     }
 
     pub(super) fn reconfigure(&mut self, config: &Config) {
-        self.relocate(config.general().offset(), config.general().anchor());
+        self.relocate(config.general().offset, &config.general().anchor);
         self.banners
-            .sort_by(config.general().sorting().get_cmp::<BannerRect>());
+            .sort_by(config.general().sorting.get_cmp::<BannerRect>());
     }
 
     fn relocate(&mut self, (x, y): (u8, u8), anchor_cfg: &config::Anchor) {
@@ -178,7 +178,7 @@ impl Window {
                 banner_rect
             }));
         self.banners
-            .sort_by(config.general().sorting().get_cmp::<BannerRect>());
+            .sort_by(config.general().sorting.get_cmp::<BannerRect>());
     }
 
     pub(super) fn replace_by_indices(
@@ -253,7 +253,7 @@ impl Window {
                 notification::Timeout::Configurable => {
                     let timeout = config
                         .display_by_app(&rect.notification().app_name)
-                        .timeout();
+                        .timeout;
                     if timeout != 0 && rect.created_at().elapsed().as_millis() > timeout as u128 {
                         Some(i)
                     } else {
@@ -276,9 +276,9 @@ impl Window {
         }
         self.pointer_state.press_state.clear();
 
-        let rect_height = config.general().height() as usize;
-        let gap = config.general().gap() as usize;
-        let anchor = config.general().anchor();
+        let rect_height = config.general().height as usize;
+        let gap = config.general().gap as usize;
+        let anchor = &config.general().anchor;
 
         if let Some(i) = (0..self.rect_size.height as usize)
             .step_by(rect_height + gap)
@@ -322,18 +322,18 @@ impl Window {
     }
 
     pub(super) fn draw(&mut self, qhandle: &QueueHandle<Window>, config: &Config) {
-        let gap = config.general().gap();
+        let gap = config.general().gap;
 
         self.resize(RectSize::new(
-            config.general().width().into(),
-            self.banners.len() * config.general().height() as usize
+            config.general().width.into(),
+            self.banners.len() * config.general().height as usize
                 + self.banners.len().saturating_sub(1) * gap as usize,
         ));
 
         let gap_buffer = self.allocate_gap_buffer(gap);
 
         self.create_buffer(qhandle);
-        self.write_banners_to_buffer(config.general().anchor(), &gap_buffer);
+        self.write_banners_to_buffer(&config.general().anchor, &gap_buffer);
         self.build_buffer(qhandle);
     }
 

--- a/crates/backend/src/window_manager.rs
+++ b/crates/backend/src/window_manager.rs
@@ -26,7 +26,7 @@ impl WindowManager {
     pub(crate) fn init(config: &Config) -> anyhow::Result<Self> {
         let connection = Connection::connect_to_env()?;
         let font_collection = Arc::new(FontCollection::load_by_font_name(
-            config.general().font().name(),
+            &config.general().font.name,
         )?);
 
         Ok(Self {

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+macros = { path = "../macros" }
 dbus = { path = "../dbus" }
 anyhow = { workspace = true }
 

--- a/crates/config/src/colors.rs
+++ b/crates/config/src/colors.rs
@@ -1,0 +1,141 @@
+use std::str::Chars;
+
+use dbus::notification::Urgency;
+use macros::ConfigProperty;
+use serde::Deserialize;
+
+use super::public;
+
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(name(UrgencyColors), derive(Debug))]
+    struct TomlUrgencyColors {
+        #[cfg_prop(use_type(Colors))]
+        low: Option<TomlColors>,
+
+        #[cfg_prop(use_type(Colors))]
+        normal: Option<TomlColors>,
+
+        #[cfg_prop(use_type(Colors), default(TomlColors::default_critical()))]
+        critical: Option<TomlColors>,
+    }
+}
+
+impl UrgencyColors {
+    pub fn by_urgency(&self, urgency: &Urgency) -> &Colors {
+        match urgency {
+            Urgency::Low => &self.low,
+            Urgency::Normal => &self.normal,
+            Urgency::Critical => &self.critical,
+        }
+    }
+}
+
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(name(Colors), derive(Debug))]
+    struct TomlColors {
+        #[cfg_prop(default(Color::new_white()))]
+        background: Option<Color>,
+        #[cfg_prop(default(Color::new_black()))]
+        foreground: Option<Color>,
+    }
+}
+
+impl TomlColors {
+    fn default_critical() -> TomlColors {
+        TomlColors {
+            background: Some(Color::new_white()),
+            foreground: Some(Color::new_red()),
+        }
+    }
+}
+
+public! {
+    #[derive(Debug, Clone, Deserialize, Default)]
+    #[serde(from = "String")]
+    struct Color {
+        red: u8,
+        green: u8,
+        blue: u8,
+        alpha: u8,
+    }
+}
+
+impl Color {
+    pub(super) fn new_white() -> Self {
+        Self {
+            red: 255,
+            green: 255,
+            blue: 255,
+            alpha: 255,
+        }
+    }
+
+    pub(super) fn new_black() -> Self {
+        Self {
+            red: 0,
+            green: 0,
+            blue: 0,
+            alpha: 255,
+        }
+    }
+
+    pub(super) fn new_red() -> Self {
+        Self {
+            red: 255,
+            green: 0,
+            blue: 0,
+            alpha: 255,
+        }
+    }
+
+    fn pre_mul_alpha(self) -> Self {
+        if self.alpha == 255 {
+            return self;
+        }
+
+        let alpha = self.alpha as f32 / 255.0;
+        Self {
+            red: (self.red as f32 * alpha) as u8,
+            green: (self.green as f32 * alpha) as u8,
+            blue: (self.blue as f32 * alpha) as u8,
+            alpha: self.alpha,
+        }
+    }
+}
+
+impl From<String> for Color {
+    fn from(value: String) -> Self {
+        const BASE: u32 = 16;
+
+        if value.len() == 4 {
+            let mut chars = value.chars();
+            chars.next(); // Skip the hashtag
+            let next_digit = |chars: &mut Chars| {
+                let digit = chars.next().unwrap().to_digit(BASE).unwrap() as u8;
+                digit * BASE as u8 + digit
+            };
+
+            Color {
+                red: next_digit(&mut chars),
+                green: next_digit(&mut chars),
+                blue: next_digit(&mut chars),
+                alpha: 255,
+            }
+        } else {
+            let data = &value[1..];
+            Color {
+                red: u8::from_str_radix(&data[0..2], BASE).unwrap(),
+                green: u8::from_str_radix(&data[2..4], BASE).unwrap(),
+                blue: u8::from_str_radix(&data[4..6], BASE).unwrap(),
+                alpha: if data.len() == 8 {
+                    u8::from_str_radix(&data[6..8], BASE).unwrap()
+                } else {
+                    255
+                },
+            }
+            .pre_mul_alpha()
+        }
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,16 +1,19 @@
+use macros::ConfigProperty;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-use std::{collections::HashMap, fs, path::Path, str::Chars, sync::Mutex};
+use std::{collections::HashMap, fs, path::Path, sync::Mutex};
 
+pub mod colors;
 pub mod sorting;
 pub mod spacing;
+pub mod text;
 pub mod watcher;
 
+use colors::{Color, TomlUrgencyColors, UrgencyColors};
 use sorting::Sorting;
 use spacing::Spacing;
+use text::{TextProperty, TomlTextProperty};
 use watcher::{ConfigState, ConfigWatcher};
-
-use dbus::notification::Urgency;
 
 pub static CONFIG: Lazy<Mutex<Config>> = Lazy::new(|| Mutex::new(Config::init()));
 
@@ -67,29 +70,45 @@ impl Config {
     ) -> (GeneralConfig, DisplayConfig, HashMap<String, DisplayConfig>) {
         let TomlConfig {
             general,
-            mut display,
+            display,
             apps,
         } = TomlConfig::parse(path);
 
-        display.fill_empty_by_default();
         let mut app_configs =
             HashMap::with_capacity(apps.as_ref().map(|data| data.len()).unwrap_or(0));
 
         if let Some(apps) = apps {
             for mut app in apps {
-                app.merge(&display);
-                app_configs.insert(app.name, app.display.unwrap());
+                app = app.merge(display.as_ref());
+                app_configs.insert(app.name, app.display.unwrap().unwrap_or_default());
             }
         }
 
-        (general, display, app_configs)
+        (
+            general.unwrap_or_default().into(),
+            display.unwrap_or_default().into(),
+            app_configs,
+        )
     }
+}
+
+#[macro_export]
+macro_rules! public {
+    ($(#[$($attr:tt)+])* struct $name:ident { $($(#[$($field_attr:tt)+])* $field:ident: $ftype:ty,)* }) => {
+        $(#[$($attr)+])*
+        pub struct $name {
+            $(
+                $(#[$($field_attr)+])*
+                pub $field: $ftype,
+            )*
+        }
+    };
 }
 
 #[derive(Debug, Deserialize, Default)]
 pub struct TomlConfig {
-    general: GeneralConfig,
-    display: DisplayConfig,
+    general: Option<TomlGeneralConfig>,
+    display: Option<TomlDisplayConfig>,
 
     #[serde(rename(deserialize = "app"))]
     apps: Option<Vec<AppConfig>>,
@@ -110,97 +129,32 @@ impl TomlConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
-#[serde(default)]
-pub struct GeneralConfig {
-    font: Font,
+public! {
+    #[derive(ConfigProperty, Default, Debug, Deserialize, Clone)]
+    #[cfg_prop(name(GeneralConfig), derive(Debug))]
+    struct TomlGeneralConfig {
+        font: Option<Font>,
 
-    #[serde(default = "GeneralConfig::default_width")]
-    width: u16,
-    #[serde(default = "GeneralConfig::default_height")]
-    height: u16,
+        #[cfg_prop(default(300))]
+        width: Option<u16>,
+        #[cfg_prop(default(150))]
+        height: Option<u16>,
 
-    anchor: Anchor,
-    offset: (u8, u8),
-    #[serde(default = "GeneralConfig::default_gap")]
-    gap: u8,
+        anchor: Option<Anchor>,
+        offset: Option<(u8, u8)>,
+        #[cfg_prop(default(10))]
+        gap: Option<u8>,
 
-    sorting: Sorting,
-}
-
-impl Default for GeneralConfig {
-    fn default() -> Self {
-        Self {
-            font: Default::default(),
-
-            width: GeneralConfig::default_width(),
-            height: GeneralConfig::default_height(),
-
-            anchor: Default::default(),
-            offset: Default::default(),
-            gap: GeneralConfig::default_gap(),
-
-            sorting: Default::default(),
-        }
+        sorting: Option<Sorting>,
     }
 }
 
-impl GeneralConfig {
-    pub fn font(&self) -> &Font {
-        &self.font
-    }
-
-    pub fn width(&self) -> u16 {
-        self.width
-    }
-
-    pub fn height(&self) -> u16 {
-        self.height
-    }
-
-    pub fn anchor(&self) -> &Anchor {
-        &self.anchor
-    }
-
-    pub fn offset(&self) -> (u8, u8) {
-        self.offset
-    }
-
-    pub fn gap(&self) -> u8 {
-        self.gap
-    }
-
-    pub fn sorting(&self) -> &Sorting {
-        &self.sorting
-    }
-
-    fn default_width() -> u16 {
-        300
-    }
-
-    fn default_height() -> u16 {
-        150
-    }
-
-    fn default_gap() -> u8 {
-        10
-    }
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[serde(from = "(String, u8)")]
-pub struct Font {
-    name: String,
-    size: u8,
-}
-
-impl Font {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn size(&self) -> u8 {
-        self.size
+public! {
+    #[derive(Debug, Deserialize, Clone)]
+    #[serde(from = "(String, u8)")]
+    struct Font {
+        name: String,
+        size: u8,
     }
 }
 
@@ -290,144 +244,45 @@ impl From<String> for Anchor {
     }
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct DisplayConfig {
-    image: Option<ImageProperty>,
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(name(DisplayConfig), derive(Debug))]
+    struct TomlDisplayConfig {
+        #[cfg_prop(use_type(ImageProperty))]
+        image: Option<TomlImageProperty>,
 
-    padding: Option<Spacing>,
-    border: Option<Border>,
+        padding: Option<Spacing>,
+        #[cfg_prop(use_type(Border))]
+        border: Option<TomlBorder>,
 
-    colors: Option<UrgencyColors>,
+        #[cfg_prop(use_type(UrgencyColors))]
+        colors: Option<TomlUrgencyColors>,
 
-    text: Option<TextProperty>,
-    title: Option<TextProperty>,
-    body: Option<TextProperty>,
-    markup: Option<bool>,
+        #[cfg_prop(temporary)]
+        text: Option<TomlTextProperty>,
 
-    timeout: Option<u16>,
-}
+        #[cfg_prop(inherits(field = text), use_type(TextProperty), default(TomlTextProperty::default_title()))]
+        title: Option<TomlTextProperty>,
 
-impl DisplayConfig {
-    pub fn image(&self) -> &ImageProperty {
-        self.image.as_ref().unwrap()
-    }
+        #[cfg_prop(inherits(field = text), use_type(TextProperty))]
+        body: Option<TomlTextProperty>,
 
-    pub fn padding(&self) -> &Spacing {
-        self.padding.as_ref().unwrap()
-    }
+        #[cfg_prop(default(true))]
+        markup: Option<bool>,
 
-    pub fn border(&self) -> &Border {
-        self.border.as_ref().unwrap()
-    }
-
-    pub fn colors(&self) -> &UrgencyColors {
-        self.colors.as_ref().unwrap()
-    }
-
-    pub fn title(&self) -> &TextProperty {
-        self.title.as_ref().unwrap()
-    }
-
-    pub fn body(&self) -> &TextProperty {
-        self.body.as_ref().unwrap()
-    }
-
-    pub fn markup(&self) -> bool {
-        self.markup.unwrap()
-    }
-
-    pub fn timeout(&self) -> u16 {
-        self.timeout.unwrap()
-    }
-
-    fn fill_empty_by_default(&mut self) {
-        if self.image.is_none() {
-            self.image = Some(Default::default());
-        }
-        self.image.as_mut().unwrap().fill_empty_by_default();
-
-        if self.padding.is_none() {
-            self.padding = Some(Default::default());
-        }
-
-        if self.border.is_none() {
-            self.border = Some(Default::default());
-        }
-        self.border.as_mut().unwrap().fill_empty_by_default();
-
-        if self.colors.is_none() {
-            self.colors = Some(Default::default());
-        }
-        self.colors.as_mut().unwrap().fill_empty_by_default();
-
-        // INFO: do not fill the text property because in will specializes to tile or body.
-        // WARNING: remember set None value to text because it is useless all the time
-        if self.text.is_none() {
-            self.text = Some(Default::default());
-        }
-
-        if self.title.is_none() {
-            self.title = Some(Default::default());
-        }
-        let title = self.title.as_mut().unwrap();
-        title.merge(self.text.as_ref().unwrap());
-        title.fill_empty_by_default("title");
-
-        if self.body.is_none() {
-            self.body = Some(Default::default());
-        }
-        let body = self.body.as_mut().unwrap();
-        body.merge(self.text.as_ref().unwrap());
-        body.fill_empty_by_default("body");
-
-        if self.markup.is_none() {
-            self.markup = Some(true);
-        }
-
-        if self.timeout.is_none() {
-            self.timeout = Some(0);
-        }
-
-        self.text = None;
+        #[cfg_prop(default(0))]
+        timeout: Option<u16>,
     }
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct ImageProperty {
-    max_size: Option<u16>,
-    margin: Option<Spacing>,
-    resizing_method: Option<ResizingMethod>,
-}
-
-impl ImageProperty {
-    pub fn max_size(&self) -> u16 {
-        self.max_size.unwrap()
-    }
-
-    pub fn margin(&self) -> &Spacing {
-        self.margin.as_ref().unwrap()
-    }
-
-    pub fn margin_mut(&mut self) -> &mut Spacing {
-        self.margin.as_mut().unwrap()
-    }
-
-    pub fn resizing_method(&self) -> &ResizingMethod {
-        self.resizing_method.as_ref().unwrap()
-    }
-
-    fn fill_empty_by_default(&mut self) {
-        if self.max_size.is_none() {
-            self.max_size = Some(64);
-        }
-
-        if self.margin.is_none() {
-            self.margin = Some(Default::default());
-        }
-
-        if self.resizing_method.is_none() {
-            self.resizing_method = Some(Default::default());
-        }
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(name(ImageProperty), derive(Debug, Clone))]
+    struct TomlImageProperty {
+        #[cfg_prop(default(64))]
+        max_size: Option<u16>,
+        margin: Option<Spacing>,
+        resizing_method: Option<ResizingMethod>,
     }
 }
 
@@ -446,431 +301,28 @@ pub enum ResizingMethod {
     Lanczos3,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct UrgencyColors {
-    low: Option<Colors>,
-    normal: Option<Colors>,
-    critical: Option<Colors>,
-}
-
-impl UrgencyColors {
-    const LOW: &'static str = "low";
-    const NORMAL: &'static str = "normal";
-    const CRITICAL: &'static str = "critical";
-
-    pub fn low(&self) -> &Colors {
-        self.low.as_ref().unwrap()
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(name(Border), derive(Debug))]
+    struct TomlBorder {
+        #[cfg_prop(default(0))]
+        size: Option<u8>,
+        #[cfg_prop(default(0))]
+        radius: Option<u8>,
+        #[cfg_prop(default(Color::new_black()))]
+        color: Option<Color>,
     }
-
-    pub fn normal(&self) -> &Colors {
-        self.normal.as_ref().unwrap()
-    }
-
-    pub fn critical(&self) -> &Colors {
-        self.critical.as_ref().unwrap()
-    }
-
-    pub fn by_urgency(&self, urgency: &Urgency) -> &Colors {
-        match urgency {
-            Urgency::Low => self.low(),
-            Urgency::Normal => self.normal(),
-            Urgency::Critical => self.critical(),
-        }
-    }
-
-    fn fill_empty_by_default(&mut self) {
-        if self.low.is_none() {
-            self.low = Some(Default::default());
-        }
-        self.low.as_mut().unwrap().fill_empty_by_default(Self::LOW);
-
-        if self.normal.is_none() {
-            self.normal = Some(Default::default());
-        }
-        self.normal
-            .as_mut()
-            .unwrap()
-            .fill_empty_by_default(Self::NORMAL);
-
-        if self.critical.is_none() {
-            self.critical = Some(Default::default());
-        }
-        let critical = self.critical.as_mut().unwrap();
-        critical.fill_empty_by_default(Self::CRITICAL);
-    }
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct Colors {
-    background: Option<Color>,
-    foreground: Option<Color>,
-}
-
-impl Colors {
-    pub fn background(&self) -> &Color {
-        self.background.as_ref().unwrap()
-    }
-
-    pub fn foreground(&self) -> &Color {
-        self.foreground.as_ref().unwrap()
-    }
-
-    fn fill_empty_by_default(&mut self, urgency: &str) {
-        if self.background.is_none() {
-            self.background = Some(Color {
-                red: 255,
-                green: 255,
-                blue: 255,
-                alpha: 255,
-            });
-        }
-
-        if self.foreground.is_none() {
-            self.foreground = Some(Color {
-                red: if urgency == UrgencyColors::CRITICAL {
-                    255
-                } else {
-                    0
-                },
-                green: 0,
-                blue: 0,
-                alpha: 255,
-            });
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(from = "String")]
-pub struct Color {
-    pub red: u8,
-    pub green: u8,
-    pub blue: u8,
-    pub alpha: u8,
-}
-
-impl Color {
-    fn pre_mul_alpha(self) -> Self {
-        if self.alpha == 255 {
-            return self;
-        }
-
-        let alpha = self.alpha as f32 / 255.0;
-        Self {
-            red: (self.red as f32 * alpha) as u8,
-            green: (self.green as f32 * alpha) as u8,
-            blue: (self.blue as f32 * alpha) as u8,
-            alpha: self.alpha,
-        }
-    }
-}
-
-impl From<String> for Color {
-    fn from(value: String) -> Self {
-        const BASE: u32 = 16;
-
-        if value.len() == 4 {
-            let mut chars = value.chars();
-            chars.next(); // Skip the hashtag
-            let next_digit = |chars: &mut Chars| {
-                let digit = chars.next().unwrap().to_digit(BASE).unwrap() as u8;
-                digit * BASE as u8 + digit
-            };
-
-            Color {
-                red: next_digit(&mut chars),
-                green: next_digit(&mut chars),
-                blue: next_digit(&mut chars),
-                alpha: 255,
-            }
-        } else {
-            let data = &value[1..];
-            Color {
-                red: u8::from_str_radix(&data[0..2], BASE).unwrap(),
-                green: u8::from_str_radix(&data[2..4], BASE).unwrap(),
-                blue: u8::from_str_radix(&data[4..6], BASE).unwrap(),
-                alpha: if data.len() == 8 {
-                    u8::from_str_radix(&data[6..8], BASE).unwrap()
-                } else {
-                    255
-                },
-            }
-            .pre_mul_alpha()
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct Border {
-    size: Option<u8>,
-    radius: Option<u8>,
-    color: Option<Color>,
-}
-
-impl Border {
-    pub fn size(&self) -> u8 {
-        self.size.unwrap()
-    }
-
-    pub fn radius(&self) -> u8 {
-        self.radius.unwrap()
-    }
-
-    pub fn color(&self) -> &Color {
-        self.color.as_ref().unwrap()
-    }
-
-    fn fill_empty_by_default(&mut self) {
-        if self.size.is_none() {
-            self.size = Some(0);
-        }
-
-        if self.radius.is_none() {
-            self.radius = Some(0);
-        }
-
-        if self.color.is_none() {
-            self.color = Some(Default::default());
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct TextProperty {
-    wrap: Option<bool>,
-    ellipsize_at: Option<EllipsizeAt>,
-
-    style: Option<TextStyle>,
-
-    margin: Option<Spacing>,
-    justification: Option<TextJustification>,
-    line_spacing: Option<u8>,
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub struct Alignment {
-    horizontal: Option<Position>,
-    vertical: Option<Position>,
-}
-
-impl Alignment {
-    pub fn new(horizontal: Position, vertical: Position) -> Self {
-        Self {
-            horizontal: Some(horizontal),
-            vertical: Some(vertical),
-        }
-    }
-
-    pub fn horizontal(&self) -> &Position {
-        self.horizontal.as_ref().unwrap()
-    }
-
-    pub fn vertical(&self) -> &Position {
-        self.vertical.as_ref().unwrap()
-    }
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub enum Position {
-    #[serde(rename = "start")]
-    Start,
-    #[default]
-    #[serde(rename = "center")]
-    Center,
-    #[serde(rename = "end")]
-    End,
-    #[serde(rename = "space-between")]
-    SpaceBetween,
-}
-
-impl Position {
-    pub fn compute_initial_pos(&self, width: usize, element_width: usize) -> usize {
-        match self {
-            Position::Start | Position::SpaceBetween => 0,
-            Position::Center => width / 2 - element_width / 2,
-            Position::End => width - element_width,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub enum TextStyle {
-    #[default]
-    #[serde(rename = "regular")]
-    Regular,
-    #[serde(rename = "bold")]
-    Bold,
-    #[serde(rename = "italic")]
-    Italic,
-    #[serde(rename = "bold italic")]
-    BoldItalic,
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub enum TextJustification {
-    #[serde(rename = "center")]
-    Center,
-    #[default]
-    #[serde(rename = "left")]
-    Left,
-    #[serde(rename = "right")]
-    Right,
-    #[serde(rename = "space-between")]
-    SpaceBetween,
-}
-
-impl TextProperty {
-    pub fn wrap(&self) -> bool {
-        self.wrap.unwrap()
-    }
-
-    pub fn ellipsize_at(&self) -> &EllipsizeAt {
-        self.ellipsize_at.as_ref().unwrap()
-    }
-
-    pub fn style(&self) -> &TextStyle {
-        self.style.as_ref().unwrap()
-    }
-
-    pub fn margin(&self) -> &Spacing {
-        self.margin.as_ref().unwrap()
-    }
-
-    pub fn justification(&self) -> &TextJustification {
-        self.justification.as_ref().unwrap()
-    }
-
-    pub fn line_spacing(&self) -> u8 {
-        self.line_spacing.unwrap()
-    }
-
-    fn merge(&mut self, other: &TextProperty) {
-        self.wrap = self.wrap.or(other.wrap);
-        self.ellipsize_at = self.ellipsize_at.clone().or(other.ellipsize_at.clone());
-        self.style = self.style.clone().or(other.style.clone());
-        self.margin = self.margin.clone().or(other.margin.clone());
-        self.justification = self.justification.clone().or(other.justification.clone());
-        self.line_spacing = self.line_spacing.or(other.line_spacing);
-    }
-
-    fn fill_empty_by_default(&mut self, entity: &str) {
-        fn is_title(entity: &str) -> bool {
-            entity == "title"
-        }
-
-        if let None = self.wrap {
-            self.wrap = Some(true);
-        }
-
-        if self.ellipsize_at.is_none() {
-            self.ellipsize_at = Some(Default::default());
-        }
-
-        if let None = self.style {
-            self.style = Some(if is_title(entity) {
-                TextStyle::Bold
-            } else {
-                Default::default()
-            });
-        }
-
-        if let None = self.margin {
-            self.margin = Some(Default::default());
-        }
-
-        if let None = self.justification {
-            self.justification = Some(if is_title(entity) {
-                TextJustification::Center
-            } else {
-                Default::default()
-            });
-        }
-
-        if let None = self.line_spacing {
-            self.line_spacing = Some(0);
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-pub enum EllipsizeAt {
-    #[serde(rename = "middle")]
-    Middle,
-    #[default]
-    #[serde(rename = "end")]
-    End,
 }
 
 #[derive(Debug, Deserialize, Default)]
 pub struct AppConfig {
     pub name: String,
-    pub display: Option<DisplayConfig>,
+    pub display: Option<TomlDisplayConfig>,
 }
 
 impl AppConfig {
-    fn merge(&mut self, other: &DisplayConfig) {
-        if let Some(display) = self.display.as_mut() {
-            if let Some(image) = display.image.as_mut() {
-                let other_image = other.image();
-
-                image.max_size = image.max_size.or(other_image.max_size);
-                image.margin = image.margin.clone().or(other_image.margin.clone());
-                image.resizing_method = image
-                    .resizing_method
-                    .clone()
-                    .or(other_image.resizing_method.clone());
-            } else {
-                display.image = other.image.clone();
-            }
-
-            display.padding = display.padding.clone().or(other.padding.clone());
-
-            if let Some(border) = display.border.as_mut() {
-                let other_border = other.border(); // The other type shall have border
-
-                border.size = border.size.or(other_border.size);
-                border.radius = border.radius.or(other_border.radius);
-                border.color = border.color.clone().or(other_border.color.clone());
-            } else {
-                display.border = other.border.clone();
-            }
-
-            if let Some(colors) = display.colors.as_mut() {
-                let other_colors = other.colors(); // The other type shall have
-                                                   // colors
-                colors.low = colors.low.clone().or(other_colors.low.clone());
-                colors.normal = colors.normal.clone().or(other_colors.normal.clone());
-                colors.critical = colors.critical.clone().or(other_colors.critical.clone());
-            } else {
-                display.colors = other.colors.clone();
-            }
-
-            {
-                if display.text.is_none() {
-                    display.text = Some(Default::default());
-                }
-
-                if display.title.is_none() {
-                    display.title = display.text.clone();
-                }
-                let title = display.title.as_mut().unwrap();
-                title.merge(display.text.as_ref().unwrap());
-                title.merge(other.title());
-
-                if display.body.is_none() {
-                    display.body = display.text.clone();
-                }
-                let body = display.body.as_mut().unwrap();
-                body.merge(display.text.as_ref().unwrap());
-                body.merge(other.body());
-
-                display.text = None;
-            }
-
-            display.markup = display.markup.or(other.markup);
-            display.timeout = display.timeout.or(other.timeout);
-        } else {
-            self.display = Some(other.clone());
-        }
+    fn merge(mut self, other: Option<&TomlDisplayConfig>) -> Self {
+        self.display = self.display.or(other.cloned());
+        self
     }
 }

--- a/crates/config/src/text.rs
+++ b/crates/config/src/text.rs
@@ -1,0 +1,66 @@
+use macros::ConfigProperty;
+use serde::Deserialize;
+
+use super::{public, Spacing};
+
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(name(TextProperty), derive(Debug, Clone))]
+    struct TomlTextProperty {
+        #[cfg_prop(default(true))]
+        wrap: Option<bool>,
+        ellipsize_at: Option<EllipsizeAt>,
+
+        style: Option<TextStyle>,
+
+        margin: Option<Spacing>,
+        justification: Option<TextJustification>,
+        #[cfg_prop(default(0))]
+        line_spacing: Option<u8>,
+    }
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub enum TextStyle {
+    #[default]
+    #[serde(rename = "regular")]
+    Regular,
+    #[serde(rename = "bold")]
+    Bold,
+    #[serde(rename = "italic")]
+    Italic,
+    #[serde(rename = "bold italic")]
+    BoldItalic,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub enum TextJustification {
+    #[serde(rename = "center")]
+    Center,
+    #[default]
+    #[serde(rename = "left")]
+    Left,
+    #[serde(rename = "right")]
+    Right,
+    #[serde(rename = "space-between")]
+    SpaceBetween,
+}
+
+impl TomlTextProperty {
+    pub(super) fn default_title() -> Self {
+        Self {
+            style: Some(TextStyle::Bold),
+            justification: Some(TextJustification::Center),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub enum EllipsizeAt {
+    #[serde(rename = "middle")]
+    Middle,
+    #[default]
+    #[serde(rename = "end")]
+    End,
+}

--- a/crates/macros/.gitignore
+++ b/crates/macros/.gitignore
@@ -1,0 +1,8 @@
+/target
+.idea
+output.png
+src/utils.rs
+debug.log
+
+# Don't save .lock files in workspaces
+Cargo.lock

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "macros"
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.86"
+quote = "1.0.36"
+syn = "2.0.72"

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,0 +1,515 @@
+use std::collections::HashMap;
+
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::{quote, ToTokens};
+use syn::{
+    braced, ext::IdentExt, parenthesized, parse::Parse, parse_macro_input, punctuated::Punctuated,
+    spanned::Spanned, Token,
+};
+
+#[proc_macro_derive(ConfigProperty, attributes(property_name, cfg_prop))]
+pub fn config_property(item: TokenStream) -> TokenStream {
+    macro_rules! propagate_err {
+        ($expr:expr) => {
+            match $expr {
+                Ok(data) => data,
+                Err(err) => return err.to_compile_error().into(),
+            }
+        };
+    }
+
+    let mut cfg_struct = parse_macro_input!(item as ConfigStructure);
+    let attr_info = propagate_err!(AttrInfo::parse_removal(&mut cfg_struct));
+
+    let mut cfg_property_struct = propagate_err!(cfg_struct.create_property_struct(&attr_info));
+    propagate_err!(cfg_property_struct.unwrap_option_types());
+    cfg_property_struct.update_field_types(&attr_info);
+
+    let mut tokens = proc_macro2::TokenStream::new();
+    cfg_property_struct.build_struct(&mut tokens, &attr_info);
+
+    propagate_err!(cfg_struct.build_impl(&mut tokens, &cfg_property_struct.name, &attr_info));
+    cfg_struct.build_impl_traits(&mut tokens, &cfg_property_struct.name, &attr_info);
+
+    tokens.into()
+}
+
+#[derive(Clone)]
+struct ConfigStructure {
+    attributes: Vec<syn::Attribute>,
+    visibility: syn::Visibility,
+    struct_token: Token![struct],
+    name: syn::Ident,
+    braces: syn::token::Brace,
+    fields: Punctuated<syn::Field, Token![,]>,
+}
+
+impl ConfigStructure {
+    fn create_property_struct(&self, attr_info: &AttrInfo) -> syn::Result<Self> {
+        let mut new_type = self.clone();
+        new_type.name = attr_info.struct_attr_info.name.clone();
+        Ok(new_type)
+    }
+
+    fn unwrap_option_types(&mut self) -> syn::Result<()> {
+        fn get_inner_type(type_path: &syn::TypePath) -> syn::Result<syn::Type> {
+            let last = type_path
+                .path
+                .segments
+                .last()
+                .expect("Must be last element of type path");
+
+            if last.ident.to_string() != "Option" {
+                return Err(syn::Error::new(
+                    type_path.span(),
+                    "Expected Option<T> type, but given another",
+                ));
+            }
+
+            let err = Err(syn::Error::new(
+                type_path.span(),
+                "Expected single <T> argument in Option<T>",
+            ));
+
+            let syn::PathArguments::AngleBracketed(arguments) = &last.arguments else {
+                return err;
+            };
+
+            let syn::GenericArgument::Type(ty) = arguments.args[0].clone() else {
+                return err;
+            };
+
+            Ok(ty)
+        }
+
+        fn get_type_path(ty: &syn::Type) -> syn::Result<&syn::TypePath> {
+            match ty {
+                syn::Type::Path(type_path) => Ok(type_path),
+                syn::Type::Group(syn::TypeGroup { elem, .. }) => get_type_path(&**elem),
+                _ => Err(syn::Error::new(
+                    ty.span(),
+                    "Invalid type, expected Option<T> type",
+                )),
+            }
+        }
+
+        for field in self.fields.iter_mut() {
+            field.ty = get_inner_type(get_type_path(&field.ty)?)?;
+        }
+
+        Ok(())
+    }
+
+    fn update_field_types(&mut self, attr_info: &AttrInfo) {
+        for field in self.fields.iter_mut() {
+            let Some(field_attr_info) = attr_info.field_attr_info.get(&field_name(field)) else {
+                continue;
+            };
+
+            let Some(use_type) = field_attr_info.use_type.clone() else {
+                continue;
+            };
+
+            field.ty = syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: syn::Path::from(use_type),
+            });
+        }
+    }
+
+    fn build_struct(&self, tokens: &mut proc_macro2::TokenStream, attr_info: &AttrInfo) {
+        self.attributes
+            .iter()
+            .for_each(|attr| attr.to_tokens(tokens));
+        if let Some(derive_info) = &attr_info.struct_attr_info.derive_info {
+            derive_info.to_tokens(tokens);
+        }
+
+        self.visibility.to_tokens(tokens);
+        self.struct_token.to_tokens(tokens);
+        self.name.to_tokens(tokens);
+        self.braces.surround(tokens, |tokens| {
+            self.fields
+                .iter()
+                .filter(|field| !attr_info.is_temporary_field(field))
+                .collect::<Punctuated<&syn::Field, Token![,]>>()
+                .to_tokens(tokens)
+        });
+    }
+
+    fn build_impl(
+        &self,
+        tokens: &mut proc_macro2::TokenStream,
+        target_type: &syn::Ident,
+        attr_info: &AttrInfo,
+    ) -> syn::Result<()> {
+        let fn_merge = self.build_fn_merge(attr_info)?;
+        let fn_unwrap_or_default = self.build_fn_unwrap_or_default(target_type, attr_info)?;
+
+        let ident = &self.name;
+        quote! {
+            impl #ident {
+                #fn_merge
+                #fn_unwrap_or_default
+            }
+        }
+        .to_tokens(tokens);
+
+        Ok(())
+    }
+
+    fn build_fn_merge(&self, _attr_info: &AttrInfo) -> syn::Result<proc_macro2::TokenStream> {
+        let fields = self
+            .fields
+            .iter()
+            .map(|field| {
+                let ident = field.ident.as_ref().expect("Must be a named field");
+
+                quote! { #ident: self.#ident.clone().or(other.#ident.clone()), }
+            })
+            .reduce(|mut lhs, rhs| {
+                lhs.extend(rhs);
+                lhs
+            })
+            .unwrap_or_default();
+
+        Ok(quote! {
+            pub fn merge(self, other: Option<Self>) -> Self {
+                if let None = other {
+                    return self;
+                }
+                let other = unsafe { other.unwrap_unchecked() };
+
+                Self {
+                    #fields
+                }
+            }
+        })
+    }
+
+    fn build_fn_unwrap_or_default(
+        &self,
+        target_type: &syn::Ident,
+        attr_info: &AttrInfo,
+    ) -> syn::Result<proc_macro2::TokenStream> {
+        let fields = self
+            .fields
+            .iter()
+            .filter(|field| !attr_info.is_temporary_field(field))
+            .map(|field| {
+                let ident = field.ident.as_ref().expect("Must be a named field");
+                let mut line = quote! { #ident: self.#ident.clone() };
+
+                if let Some(field_char) = attr_info.field_attr_info.get(&ident.to_string()) {
+                    if let Some(InheritsField(target)) = &field_char.inherits {
+                        quote! {
+                            .map(|val| val.merge(self.#target.clone()))
+                            .or(self.#target.clone())
+                        }
+                        .to_tokens(&mut line);
+                    }
+
+                    match &field_char.default {
+                        DefaultAssignment::Expression(expr) => {
+                            quote! { .unwrap_or(#expr) }.to_tokens(&mut line)
+                        }
+                        DefaultAssignment::FunctionCall(function_path) => {
+                            quote! { .unwrap_or(#function_path()) }.to_tokens(&mut line)
+                        }
+                        DefaultAssignment::DefaultCall => {
+                            quote! { .unwrap_or_default() }.to_tokens(&mut line);
+                        }
+                    }
+
+                    if let Some(_) = field_char.use_type {
+                        quote! { .into() }.to_tokens(&mut line);
+                    }
+                } else {
+                    quote! { .unwrap_or_default() }.to_tokens(&mut line);
+                }
+
+                quote! { , }.to_tokens(&mut line);
+
+                line
+            })
+            .reduce(|mut lhs, rhs| {
+                lhs.extend(rhs);
+                lhs
+            })
+            .unwrap_or_default();
+
+        Ok(quote! {
+            pub fn unwrap_or_default(&self) -> #target_type {
+                #target_type {
+                    #fields
+                }
+            }
+        })
+    }
+
+    fn build_impl_traits(
+        &self,
+        tokens: &mut proc_macro2::TokenStream,
+        target_type: &syn::Ident,
+        _attr_info: &AttrInfo,
+    ) {
+        let self_name = &self.name;
+        quote! {
+            impl From<#self_name> for #target_type {
+                fn from(value: #self_name) -> #target_type {
+                    value.unwrap_or_default()
+                }
+            }
+        }
+        .to_tokens(tokens);
+    }
+}
+
+impl Parse for ConfigStructure {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let content;
+        Ok(Self {
+            attributes: input.call(syn::Attribute::parse_outer)?,
+            visibility: input.parse()?,
+            struct_token: input.parse()?,
+            name: input.parse()?,
+            braces: braced!(content in input),
+            fields: content.parse_terminated(syn::Field::parse_named, Token![,])?,
+        })
+    }
+}
+
+struct AttrInfo {
+    struct_attr_info: StructAttrInfo,
+    field_attr_info: HashMap<String, FieldAttrInfo>,
+}
+
+impl AttrInfo {
+    fn parse_removal(cfg_struct: &mut ConfigStructure) -> syn::Result<Self> {
+        fn removed_suitable_attr(attributes: &mut Vec<syn::Attribute>) -> Option<syn::Attribute> {
+            let index = attributes
+                .iter()
+                .enumerate()
+                .find_map(|(i, attr)| AttrInfo::is_cfg_prop(attr).then_some(i));
+
+            index.map(|index| attributes.remove(index))
+        }
+
+        fn attr_tokens(attr: syn::Attribute) -> syn::Result<proc_macro2::TokenStream> {
+            if let syn::Meta::List(meta_list) = attr.meta {
+                Ok(meta_list.tokens)
+            } else {
+                return Err(syn::Error::new(
+                    attr.span(),
+                    "Expected attribute like #[cfg_prop()]",
+                ));
+            }
+        }
+
+        let Some(outer_attribute) = removed_suitable_attr(&mut cfg_struct.attributes) else {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "Expected #[cfg_struct(name(StructName))] as outer attribute but it isn't provided",
+            ));
+        };
+        let struct_attr_info = syn::parse2(attr_tokens(outer_attribute)?)?;
+
+        let mut field_attr_info = HashMap::new();
+
+        for field in cfg_struct.fields.iter_mut() {
+            let field_name = field_name(&field);
+            let Some(field_attribute) = removed_suitable_attr(&mut field.attrs) else {
+                continue;
+            };
+
+            field_attr_info.insert(field_name, syn::parse2(attr_tokens(field_attribute)?)?);
+        }
+
+        Ok(Self {
+            struct_attr_info,
+            field_attr_info,
+        })
+    }
+
+    fn is_temporary_field(&self, field: &syn::Field) -> bool {
+        self.field_attr_info
+            .get(&field_name(field))
+            .map(|field_info| field_info.temporary)
+            .unwrap_or(false)
+    }
+
+    fn is_cfg_prop(attr: &syn::Attribute) -> bool {
+        if let syn::Meta::List(meta_list) = &attr.meta {
+            if meta_list.path.is_ident("cfg_prop") {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+struct StructAttrInfo {
+    name: syn::Ident,
+    derive_info: Option<DeriveInfo>,
+}
+
+impl Parse for StructAttrInfo {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let beginning_span = input.span();
+        let mut name = None;
+        let mut derive_info = None;
+
+        loop {
+            let ident = input.parse::<syn::Ident>()?;
+
+            match ident.to_string().as_str() {
+                "name" => {
+                    let content;
+                    let _paren = parenthesized!(content in input);
+                    name = Some(content.parse()?);
+                }
+                "derive" => {
+                    let content;
+                    derive_info = Some(DeriveInfo {
+                        ident,
+                        paren: parenthesized!(content in input),
+                        traits: content.parse_terminated(syn::Ident::parse_any, Token![,])?,
+                    });
+                }
+                _ => return Err(syn::Error::new(ident.span(), "Unknown attribute")),
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            } else {
+                break;
+            }
+        }
+
+        let Some(name) = name else {
+            return Err(syn::Error::new(
+                beginning_span,
+                "Expected \"name\" property for creating new struct, but it doesn't given",
+            ));
+        };
+
+        Ok(Self { name, derive_info })
+    }
+}
+
+struct DeriveInfo {
+    ident: syn::Ident,
+    paren: syn::token::Paren,
+    traits: Punctuated<syn::Ident, Token![,]>,
+}
+
+impl ToTokens for DeriveInfo {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        proc_macro2::Punct::new('#', proc_macro2::Spacing::Joint).to_tokens(tokens);
+        syn::token::Bracket::default().surround(tokens, |tokens| {
+            self.ident.to_tokens(tokens);
+            self.paren
+                .surround(tokens, |tokens| self.traits.to_tokens(tokens));
+        });
+    }
+}
+
+struct FieldAttrInfo {
+    temporary: bool,
+    default: DefaultAssignment,
+    inherits: Option<InheritsField>,
+    use_type: Option<syn::Ident>,
+}
+
+impl Parse for FieldAttrInfo {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut temporary = false;
+        let mut default = DefaultAssignment::DefaultCall;
+        let mut inherits: Option<InheritsField> = None;
+        let mut use_type: Option<syn::Ident> = None;
+
+        loop {
+            let ident = input.parse::<syn::Ident>()?;
+
+            match ident.to_string().as_str() {
+                "temporary" => temporary = true,
+                "default" => {
+                    let content;
+                    let _paren = parenthesized!(content in input);
+                    default = content.parse()?;
+                }
+                "inherits" => {
+                    let content;
+                    let _paren = parenthesized!(content in input);
+                    inherits = Some(content.parse()?);
+                }
+                "use_type" => {
+                    let content;
+                    let _paren = parenthesized!(content in input);
+                    use_type = Some(content.parse()?);
+                }
+                _ => return Err(syn::Error::new(ident.span(), "Unknown attribute")),
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            } else {
+                break;
+            }
+        }
+
+        Ok(Self {
+            temporary,
+            default,
+            inherits,
+            use_type,
+        })
+    }
+}
+
+enum DefaultAssignment {
+    DefaultCall,
+    Expression(syn::Expr),
+    FunctionCall(syn::Path),
+}
+
+impl Parse for DefaultAssignment {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(if input.peek(Ident::peek_any) && input.peek2(Token![=]) {
+            let _ = input.parse::<syn::Ident>()?;
+            let _ = input.parse::<Token![=]>()?;
+            DefaultAssignment::FunctionCall(input.parse()?)
+        } else {
+            DefaultAssignment::Expression(input.parse()?)
+        })
+    }
+}
+
+struct InheritsField(syn::Ident);
+
+impl Parse for InheritsField {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let argument: Ident = input.parse()?;
+
+        if argument.to_string().as_str() != "field" {
+            return Err(syn::parse::Error::new(
+                argument.span(),
+                "Invalid argument. Currently possible only \"field\".",
+            ));
+        }
+
+        let _eq_token = input.parse::<Token![=]>()?;
+
+        Ok(Self(input.parse()?))
+    }
+}
+
+fn field_name(field: &syn::Field) -> String {
+    field
+        .ident
+        .as_ref()
+        .expect("Must be a named field")
+        .to_string()
+}


### PR DESCRIPTION
# Motivation

Because of the current code in the config crate is horrible to maintain I invented time to write derive macro which must reduce the code amount and grow it in more effective way.

I'll write documentation and README file for this macro a little bit later.