### PR TITLE
feat: add image rounding by config property

### DIFF
--- a/crates/backend/src/render/widget.rs
+++ b/crates/backend/src/render/widget.rs
@@ -18,6 +18,7 @@ pub(super) enum DrawColor {
     Replace(Bgra),
     Overlay(Bgra),
     OverlayWithCoverage(Bgra, Coverage),
+    Transparent(Coverage),
 }
 
 pub(super) trait Draw {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -281,6 +281,8 @@ public! {
     struct TomlImageProperty {
         #[cfg_prop(default(64))]
         max_size: Option<u16>,
+        #[cfg_prop(default(0))]
+        rounding: Option<u16>,
         margin: Option<Spacing>,
         resizing_method: Option<ResizingMethod>,
     }


### PR DESCRIPTION
# Changes

- Added `DrawColor::Transpasent(Coverage)` for changing background color by coverage factor;
- Instead of transferring background color to all widgets uses real background color by getting from framebuffer;
- Extended Border impl with new methods - `compile` and `get_color_at`, which is very helpful for image rounding;
- Added property `display.image.rounding` which accepts `u8` integer and used as border radius for image. (Default value: 0).