### PR TITLE
feat: use user defined path to config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,6 @@ dependencies = [
  "dbus",
  "inotify",
  "macros",
- "once_cell",
  "serde",
  "toml",
 ]

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -1,6 +1,7 @@
 use std::thread;
 
 use anyhow::Context;
+use config::Config;
 use tokio::sync::mpsc::unbounded_channel;
 
 mod internal_messages;
@@ -13,11 +14,11 @@ use dbus::server::Server;
 
 use render::Renderer;
 
-pub async fn run() -> anyhow::Result<()> {
+pub async fn run(config: Config) -> anyhow::Result<()> {
     let (sender, mut receiver) = unbounded_channel();
     let server = Server::init(sender).await?;
 
-    let (server_internal_channel, mut renderer) = Renderer::init()?;
+    let (server_internal_channel, mut renderer) = Renderer::init(config)?;
 
     let backend_thread = thread::spawn(move || renderer.run());
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -10,6 +10,5 @@ dbus = { path = "../dbus" }
 anyhow = { workspace = true }
 
 inotify = "0.10.2"
-once_cell = "1.19.0"
 serde = "1.0.205"
 toml = "0.8.19"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,7 +1,6 @@
 use macros::ConfigProperty;
-use once_cell::sync::Lazy;
 use serde::Deserialize;
-use std::{collections::HashMap, fs, path::Path, sync::Mutex};
+use std::{collections::HashMap, fs, path::Path};
 
 pub mod colors;
 pub mod sorting;
@@ -15,8 +14,6 @@ use spacing::Spacing;
 use text::{TextProperty, TomlTextProperty};
 use watcher::{ConfigState, ConfigWatcher};
 
-pub static CONFIG: Lazy<Mutex<Config>> = Lazy::new(|| Mutex::new(Config::init()));
-
 #[derive(Debug)]
 pub struct Config {
     watcher: ConfigWatcher,
@@ -27,8 +24,9 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn init() -> Self {
-        let watcher = ConfigWatcher::init().expect("The config watcher must be initialized");
+    pub fn init(user_config: Option<&str>) -> Self {
+        let watcher =
+            ConfigWatcher::init(user_config).expect("The config watcher must be initialized");
 
         let (general, display, app_configs) = Self::parse(watcher.get_config_path());
 


### PR DESCRIPTION
Now user can define a path to config file using `-c` or `--config` flag.

Also I changed scope of `Config` struct from global to function-local for reducing further errors with `std::sync::Mutex<T>`.