### PR TITLE
feat: make `FlexContainer` more flexible

### DIFF
--- a/crates/backend/src/render/banner.rs
+++ b/crates/backend/src/render/banner.rs
@@ -10,7 +10,7 @@ use super::{
     font::FontCollection,
     types::RectSize,
     widget::{
-        self, Alignment, ContainerBuilder, Coverage, Draw, DrawColor, Position, WImage, WText,
+        self, Alignment, Coverage, Draw, DrawColor, FlexContainerBuilder, Position, WImage, WText,
     },
 };
 
@@ -91,13 +91,13 @@ impl BannerRect {
 
         let font_size = config.general().font.size as f32;
 
-        let mut container = ContainerBuilder::default()
+        let mut container = FlexContainerBuilder::default()
             .spacing(padding)
             .direction(widget::Direction::Horizontal)
             .alignment(Alignment::new(Position::Start, Position::Center))
             .elements(vec![
                 WImage::new(&self.data, display).into(),
-                ContainerBuilder::default()
+                FlexContainerBuilder::default()
                     .spacing(Default::default())
                     .direction(widget::Direction::Vertical)
                     .alignment(Alignment::new(Position::Center, Position::Center))

--- a/crates/backend/src/render/types.rs
+++ b/crates/backend/src/render/types.rs
@@ -24,8 +24,12 @@ impl RectSize {
     }
 
     pub(crate) fn shrink_by(&mut self, spacing: &Spacing) {
-        self.width -= spacing.left() as usize + spacing.right() as usize;
-        self.height -= spacing.top() as usize + spacing.bottom() as usize;
+        self.width = self
+            .width
+            .saturating_sub(spacing.left() as usize + spacing.right() as usize);
+        self.height = self
+            .height
+            .saturating_sub(spacing.top() as usize + spacing.bottom() as usize);
     }
 
     pub(crate) fn area(&self) -> usize {

--- a/crates/config/src/spacing.rs
+++ b/crates/config/src/spacing.rs
@@ -69,8 +69,8 @@ impl Spacing {
     }
 
     pub fn shrink(&self, width: &mut usize, height: &mut usize) {
-        *width -= self.left as usize + self.right as usize;
-        *height -= self.top as usize + self.bottom as usize;
+        *width = width.saturating_sub(self.left as usize + self.right as usize);
+        *height = height.saturating_sub(self.top as usize + self.bottom as usize);
     }
 }
 


### PR DESCRIPTION
# Motivation

The `Container` type is unbounded that means inner widget containers will fill available space which is not good for particular cases. Especially in future, where we can add custom layout by filetype.
So this changes have solution via 'max-width` and `max-height`.

## Changes

Adds `max-width` and `max-height` for `FlexContainer`. Also I've changed name from `Container` to `FlexContainer` which makes more sense.

With this I've fixed some mistakes with overflowing and ellipsization that have found during development.