### PR TITLE
feat: notification scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,9 +331,14 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "config",
  "dbus",
  "filetype",
+ "derive_builder",
+ "derive_more",
+ "humantime",
+ "image",
  "indexmap",
  "log",
  "render",
@@ -470,6 +490,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +589,12 @@ dependencies = [
  "shellexpand",
  "toml",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_maths"
@@ -1113,6 +1153,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1332,15 @@ name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kurbo"
@@ -2885,6 +2957,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,10 +335,7 @@ dependencies = [
  "config",
  "dbus",
  "filetype",
- "derive_builder",
- "derive_more",
  "humantime",
- "image",
  "indexmap",
  "log",
  "render",
@@ -500,7 +497,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2964,7 +2961,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/app/cli.rs
+++ b/crates/app/cli.rs
@@ -124,7 +124,6 @@ pub struct SendCommand {
     resident: Option<bool>,
 
     #[arg(
-        short,
         long,
         help = "Sound file",
         long_help = "Path to a sound file to play when the notification pops up"
@@ -162,6 +161,14 @@ pub struct SendCommand {
         long_help = "Interprets action IDs as icons, annotated by display names"
     )]
     action_icons: Option<bool>,
+
+    #[arg(
+        short = 's',
+        long,
+        help = "Schedule",
+        long_help = "Schedule notification"
+    )]
+    schedule: String,
 }
 
 impl Args {
@@ -210,6 +217,7 @@ async fn send(noti: client::NotiClient<'_>, args: SendCommand) -> anyhow::Result
         args.timeout,
         args.actions,
         args.hints,
+        args.schedule,
         hints_data,
     )
     .await

--- a/crates/app/cli.rs
+++ b/crates/app/cli.rs
@@ -168,7 +168,7 @@ pub struct SendCommand {
         help = "Schedule",
         long_help = "Specifies the time to schedule the notification to be shown."
     )]
-    schedule: String,
+    schedule: Option<String>,
 }
 
 impl Args {
@@ -206,6 +206,7 @@ async fn send(noti: client::NotiClient<'_>, args: SendCommand) -> anyhow::Result
         suppress_sound: args.suppress_sound,
         transient: args.transient,
         action_icons: args.action_icons,
+        schedule: args.schedule,
     };
 
     noti.send_notification(
@@ -217,7 +218,6 @@ async fn send(noti: client::NotiClient<'_>, args: SendCommand) -> anyhow::Result
         args.timeout,
         args.actions,
         args.hints,
-        args.schedule,
         hints_data,
     )
     .await

--- a/crates/app/cli.rs
+++ b/crates/app/cli.rs
@@ -166,7 +166,7 @@ pub struct SendCommand {
         short = 's',
         long,
         help = "Schedule",
-        long_help = "Schedule notification"
+        long_help = "Specifies the time to schedule the notification to be shown."
     )]
     schedule: String,
 }

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -19,3 +19,5 @@ wayland-client = "0.31.5"
 wayland-protocols = { version = "0.32.3", features = ["client", "wayland-client"] }
 wayland-protocols-wlr = { version = "0.3.3", features = ["client", "wayland-client"] }
 indexmap = "2.4.0"
+humantime = "2.1.0"
+chrono = "0.4.39"

--- a/crates/backend/src/scheduler.rs
+++ b/crates/backend/src/scheduler.rs
@@ -63,9 +63,16 @@ impl Scheduler {
         }
 
         const DATETIME_FORMATS: &[&str] = &[
-            "%d.%m.%Y %H:%M",    // 01.01.2025 00:00
-            "%Y-%m-%d %H:%M",    // 2025-01-01 00:00
+            "%Y.%m.%d %H:%M", // 2025.01.01 00:00
+            "%Y-%m-%d %H:%M", // 2025-01-01 00:00
+            //
+            "%d.%m.%Y %H:%M", // 01.01.2025 00:00
+            "%d-%m-%Y %H:%M", // 01-01-2025 00:00
+            //
             "%d.%m.%Y %I:%M %p", // 01.01.2025 12:00 AM
+            "%d-%m-%Y %I:%M %p", // 01-01-2025 12:00 AM
+            //
+            "%Y.%m.%d %I:%M %p", // 2025.01.01 12:00 AM
             "%Y-%m-%d %I:%M %p", // 2025-01-01 12:00 AM
         ];
 
@@ -74,30 +81,22 @@ impl Scheduler {
             "%I:%M %p", // 06:45 PM
         ];
 
-        if let Some(datetime) = DATETIME_FORMATS
-            .iter()
-            .filter_map(|&format| {
-                NaiveDateTime::parse_from_str(time_str, format)
-                    .ok()
-                    .map(|parsed| Self::from_local_to_utc(&parsed))
-            })
-            .next()
-        {
+        if let Some(datetime) = DATETIME_FORMATS.iter().find_map(|&format| {
+            NaiveDateTime::parse_from_str(time_str, format)
+                .ok()
+                .map(|parsed| Self::from_local_to_utc(&parsed))
+        }) {
             return Ok(datetime);
         }
 
-        if let Some(datetime) = TIME_FORMATS
-            .iter()
-            .filter_map(|&format| {
-                NaiveTime::parse_from_str(time_str, format)
-                    .ok()
-                    .map(|parsed| {
-                        let today = Local::now().date_naive();
-                        Self::from_local_to_utc(&today.and_time(parsed))
-                    })
-            })
-            .next()
-        {
+        if let Some(datetime) = TIME_FORMATS.iter().find_map(|&format| {
+            NaiveTime::parse_from_str(time_str, format)
+                .ok()
+                .map(|parsed| {
+                    let today = Local::now().date_naive();
+                    Self::from_local_to_utc(&today.and_time(parsed))
+                })
+        }) {
             return Ok(datetime);
         }
 

--- a/crates/backend/src/scheduler.rs
+++ b/crates/backend/src/scheduler.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use chrono::{DateTime, Local, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use dbus::notification::ScheduledNotification;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;

--- a/crates/backend/src/scheduler.rs
+++ b/crates/backend/src/scheduler.rs
@@ -1,0 +1,60 @@
+use chrono::{DateTime, Utc};
+use dbus::notification::ScheduledNotification;
+use humantime::parse_duration;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
+pub struct Scheduler {
+    queue: BinaryHeap<Reverse<ScheduledNotification>>,
+}
+
+impl Scheduler {
+    pub fn new() -> Self {
+        Scheduler {
+            queue: BinaryHeap::new(),
+        }
+    }
+
+    pub fn add(&mut self, notification: ScheduledNotification) {
+        let time = match Self::parse_time(&notification.time) {
+            Ok(parsed_time) => parsed_time,
+            Err(e) => {
+                eprintln!("Error parsing time '{}': {}", notification.time, e);
+                return;
+            }
+        };
+
+        let scheduled_notification = ScheduledNotification {
+            time: time.to_rfc3339(),
+            data: notification.data,
+            id: notification.id,
+        };
+
+        self.queue.push(Reverse(scheduled_notification));
+    }
+
+    fn parse_time(time_str: &str) -> Result<DateTime<Utc>, chrono::ParseError> {
+        let now = Utc::now();
+
+        if let Ok(duration) = parse_duration(time_str) {
+            Ok(now + chrono::Duration::from_std(duration).unwrap())
+        } else {
+            time_str.parse::<DateTime<Utc>>()
+        }
+    }
+
+    pub fn pop_due_notifications(&mut self) -> Vec<ScheduledNotification> {
+        let now = Utc::now();
+        let mut due_notifications = Vec::new();
+
+        while let Some(Reverse(top)) = self.queue.peek() {
+            if top.time.parse::<DateTime<Utc>>().unwrap() <= now {
+                due_notifications.push(self.queue.pop().unwrap().0);
+            } else {
+                break;
+            }
+        }
+
+        due_notifications
+    }
+}

--- a/crates/backend/src/scheduler.rs
+++ b/crates/backend/src/scheduler.rs
@@ -72,7 +72,7 @@ impl Scheduler {
             }
         }
 
-        Ok(time_str.parse::<DateTime<Utc>>()?)
+        time_str.parse::<DateTime<Utc>>()
     }
 
     pub fn pop_due_notifications(&mut self) -> Vec<ScheduledNotification> {

--- a/crates/backend/src/scheduler.rs
+++ b/crates/backend/src/scheduler.rs
@@ -1,6 +1,5 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use dbus::notification::ScheduledNotification;
-use humantime::parse_duration;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 
@@ -14,33 +13,66 @@ impl Scheduler {
             queue: BinaryHeap::new(),
         }
     }
-
     pub fn add(&mut self, notification: ScheduledNotification) {
-        let time = match Self::parse_time(&notification.time) {
-            Ok(parsed_time) => parsed_time,
+        match Self::parse_time(&notification.time) {
+            Ok(parsed_time) => {
+                dbg!(&parsed_time);
+
+                let scheduled_notification = ScheduledNotification {
+                    time: parsed_time.to_rfc3339(),
+                    data: notification.data,
+                    id: notification.id,
+                };
+                self.queue.push(Reverse(scheduled_notification));
+            }
             Err(e) => {
                 eprintln!("Error parsing time '{}': {}", notification.time, e);
-                return;
             }
-        };
-
-        let scheduled_notification = ScheduledNotification {
-            time: time.to_rfc3339(),
-            data: notification.data,
-            id: notification.id,
-        };
-
-        self.queue.push(Reverse(scheduled_notification));
+        }
     }
 
     fn parse_time(time_str: &str) -> Result<DateTime<Utc>, chrono::ParseError> {
         let now = Utc::now();
 
-        if let Ok(duration) = parse_duration(time_str) {
-            Ok(now + chrono::Duration::from_std(duration).unwrap())
-        } else {
-            time_str.parse::<DateTime<Utc>>()
+        if let Ok(duration) = humantime::parse_duration(time_str) {
+            return Ok(now + chrono::Duration::from_std(duration).unwrap());
         }
+
+        let datetime_formats = [
+            "%d.%m.%Y %H:%M",    // 01.01.2025 00:00
+            "%Y-%m-%d %H:%M",    // 01-01-2025 00:00
+            "%d.%m.%Y %I:%M %p", // 01.01.2025 12:00 AM
+            "%Y-%m-%d %I:%M %p", // 01-01-2025 12:00 AM
+        ];
+
+        for format in &datetime_formats {
+            if let Ok(datetime) = NaiveDateTime::parse_from_str(time_str, format) {
+                return Ok(Local
+                    .from_local_datetime(&datetime)
+                    .single()
+                    .expect("Ambiguous local time")
+                    .with_timezone(&Utc));
+            }
+        }
+
+        let time_formats = [
+            "%H:%M",    // 18:45
+            "%I:%M %p", // 06:45 PM
+        ];
+
+        for format in &time_formats {
+            if let Ok(time) = NaiveTime::parse_from_str(time_str, format) {
+                let today = Local::now().date_naive();
+                let datetime = today.and_time(time);
+                return Ok(Local
+                    .from_local_datetime(&datetime)
+                    .single()
+                    .expect("Ambiguous local time")
+                    .with_timezone(&Utc));
+            }
+        }
+
+        Ok(time_str.parse::<DateTime<Utc>>()?)
     }
 
     pub fn pop_due_notifications(&mut self) -> Vec<ScheduledNotification> {
@@ -48,10 +80,11 @@ impl Scheduler {
         let mut due_notifications = Vec::new();
 
         while let Some(Reverse(top)) = self.queue.peek() {
-            if top.time.parse::<DateTime<Utc>>().unwrap() <= now {
-                due_notifications.push(self.queue.pop().unwrap().0);
-            } else {
-                break;
+            match top.time.parse::<DateTime<Utc>>() {
+                Ok(time) if time <= now => {
+                    due_notifications.push(self.queue.pop().unwrap().0);
+                }
+                _ => break,
             }
         }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -39,10 +39,13 @@ impl<'a> NotiClient<'a> {
         timeout: i32,
         actions: Vec<String>,
         hints: Vec<String>,
+        schedule: String,
         hints_data: HintsData,
     ) -> anyhow::Result<()> {
         debug!("Client: Building hints and actions from user prompt");
-        let new_hints = build_hints(&hints, hints_data)?;
+        let mut new_hints = build_hints(&hints, hints_data)?;
+        new_hints.insert("schedule", Value::new(schedule));
+
         let actions = build_actions(&actions)?;
 
         debug!(

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -14,6 +14,7 @@ pub struct HintsData {
     pub suppress_sound: Option<bool>,
     pub transient: Option<bool>,
     pub action_icons: Option<bool>,
+    pub schedule: Option<String>,
 }
 
 pub struct NotiClient<'a> {
@@ -39,12 +40,10 @@ impl<'a> NotiClient<'a> {
         timeout: i32,
         actions: Vec<String>,
         hints: Vec<String>,
-        schedule: String,
         hints_data: HintsData,
     ) -> anyhow::Result<()> {
         debug!("Client: Building hints and actions from user prompt");
-        let mut new_hints = build_hints(&hints, hints_data)?;
-        new_hints.insert("schedule", Value::new(schedule));
+        let new_hints = build_hints(&hints, hints_data)?;
 
         let actions = build_actions(&actions)?;
 
@@ -133,6 +132,7 @@ fn build_hints<'a>(
     hints_map.insert_if_empty("image-path", hints_data.image_path, Value::from);
     hints_map.insert_if_empty("sound-file", hints_data.sound_file, Value::from);
     hints_map.insert_if_empty("sound-name", hints_data.sound_name, Value::from);
+    hints_map.insert_if_empty("schedule", hints_data.schedule, Value::from);
     hints_map.insert_if_empty("resident", hints_data.resident, Value::Bool);
     hints_map.insert_if_empty("suppress-sound", hints_data.suppress_sound, Value::Bool);
     hints_map.insert_if_empty("transient", hints_data.transient, Value::Bool);

--- a/crates/dbus/src/actions.rs
+++ b/crates/dbus/src/actions.rs
@@ -1,9 +1,12 @@
 use derive_more::derive::Display;
 
+use crate::notification::ScheduledNotification;
+
 use super::notification::Notification;
 
 pub enum Action {
     Show(Box<Notification>),
+    Schedule(ScheduledNotification),
     ShowLast, // NOTE: consider removing this
     Close(Option<u32>),
     CloseAll,

--- a/crates/dbus/src/actions.rs
+++ b/crates/dbus/src/actions.rs
@@ -7,7 +7,6 @@ use super::notification::Notification;
 pub enum Action {
     Show(Box<Notification>),
     Schedule(ScheduledNotification),
-    ShowLast, // NOTE: consider removing this
     Close(Option<u32>),
     CloseAll,
 }

--- a/crates/dbus/src/notification.rs
+++ b/crates/dbus/src/notification.rs
@@ -17,6 +17,33 @@ pub struct Notification {
     pub created_at: u64,
 }
 
+#[derive(Debug)]
+pub struct ScheduledNotification {
+    pub id: u32,
+    pub time: String,
+    pub data: Box<Notification>,
+}
+
+impl Ord for ScheduledNotification {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.time.cmp(&other.time)
+    }
+}
+
+impl PartialOrd for ScheduledNotification {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.time.cmp(&other.time))
+    }
+}
+
+impl PartialEq for ScheduledNotification {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+    }
+}
+
+impl Eq for ScheduledNotification {}
+
 #[derive(Debug, Clone)]
 pub struct Hints {
     /// The urgency level.
@@ -63,6 +90,7 @@ pub struct Hints {
     /// The localized display name will be used to annotate the icon for accessibility purposes.
     /// The icon name should be compliant with the Freedesktop.org Icon Naming Specification.
     pub action_icons: Option<bool>,
+    pub schedule: Option<String>,
 }
 
 impl Hints {
@@ -99,6 +127,7 @@ impl From<HashMap<&str, Value<'_>>> for Hints {
         let suppress_sound = Self::get_hint_value(&hints, "suppress-sound");
         let transient = Self::get_hint_value(&hints, "transient");
         let action_icons = Self::get_hint_value(&hints, "action_icons");
+        let schedule = Self::get_hint_value(&hints, "schedule");
         let coordinates = Coordinates::from_hints(&hints);
 
         Hints {
@@ -114,6 +143,7 @@ impl From<HashMap<&str, Value<'_>>> for Hints {
             transient,
             coordinates,
             action_icons,
+            schedule,
         }
     }
 }

--- a/crates/dbus/src/notification.rs
+++ b/crates/dbus/src/notification.rs
@@ -90,6 +90,8 @@ pub struct Hints {
     /// The localized display name will be used to annotate the icon for accessibility purposes.
     /// The icon name should be compliant with the Freedesktop.org Icon Naming Specification.
     pub action_icons: Option<bool>,
+
+    /// Specifies the time to schedule the notification to be shown.
     pub schedule: Option<String>,
 }
 

--- a/crates/dbus/src/server.rs
+++ b/crates/dbus/src/server.rs
@@ -105,14 +105,29 @@ impl Handler {
             app_icon,
             summary,
             body,
-            hints,
+            hints: hints.clone(),
             actions,
             expire_timeout,
             created_at,
             is_read: false,
         };
 
-        self.sender.send(Action::Show(notification.into())).unwrap();
+        if let Some(schedule) = &hints.schedule {
+            let scheduled_notification = crate::notification::ScheduledNotification {
+                id: notification.id,
+                time: schedule.to_owned(),
+                data: notification.into(),
+            };
+
+            dbg!(&scheduled_notification);
+
+            self.sender
+                .send(Action::Schedule(scheduled_notification))
+                .unwrap();
+        } else {
+            self.sender.send(Action::Show(notification.into())).unwrap();
+        }
+
         Ok(id)
     }
 

--- a/crates/dbus/src/server.rs
+++ b/crates/dbus/src/server.rs
@@ -105,21 +105,19 @@ impl Handler {
             app_icon,
             summary,
             body,
-            hints: hints.clone(),
+            hints,
             actions,
             expire_timeout,
             created_at,
             is_read: false,
         };
 
-        if let Some(schedule) = &hints.schedule {
+        if let Some(schedule) = &notification.hints.schedule {
             let scheduled_notification = crate::notification::ScheduledNotification {
                 id: notification.id,
                 time: schedule.to_owned(),
                 data: notification.into(),
             };
-
-            dbg!(&scheduled_notification);
 
             self.sender
                 .send(Action::Schedule(scheduled_notification))


### PR DESCRIPTION
This pull-request implements the feature discussed in #32
It adds support for scheduling notifications with the `--schedule` flag in the `send` command.

#### Supported Date and Time Formats:
- Human readable duration (e.g., "2 hours", "10 minutes", "1m 25s")
- `%d.%m.%Y %H:%M` — 01.01.2025 00:00
- `%d-%m-%Y %H:%M` — 01-01-2025 00:00
- `%Y.%m.%d %H:%M` — 2025.01.01 00:00
- `%Y-%m-%d %H:%M` — 2025-01-01 00:00
- `%d.%m.%Y %I:%M %p` — 01.01.2025 12:00 AM
- `%d-%m-%Y %I:%M %p` — 01-01-2025 12:00 AM
- `%Y.%m.%d %I:%M %p` — 2025.01.01 12:00 AM
- `%Y-%m-%d %I:%M %p` — 2025-01-01 12:00 AM
- `%H:%M` — 18:45
- `%I:%M %p` — 06:45 PM
- `RFC 3339`/`ISO 8601` UTC string


#### Usage:
```rs
noti send --schedule "30 minutes" "Reminder" "Take a break" --timeout 0
```