### PR TITLE
feat: add `import` of config files and introduce color theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Noti uses a TOML configuration file located at:
 
 ```toml
 [general]
-font = [ "JetBrainsMono Nerd Font", 16 ]
+font = "JetBrainsMono Nerd Font"
 anchor = "top-right"
 offset = [15, 15]
 gap = 10
@@ -92,10 +92,12 @@ ellipsize_at = "middle"
 [display.title]
 style = "bold italic"
 margin = { top = 5 }
+font_size = 18
 
 [display.body]
 justification = "left"
 margin = { top = 12 }
+font_size = 16
 
 [[theme]]
 name = "pastel"

--- a/README.md
+++ b/README.md
@@ -71,21 +71,13 @@ width = 300
 height = 150
 
 [display]
+theme = "pastel"
 padding = 8
 timeout = 2000
-
-[display.colors.normal]
-background = "#1e1e2e"
-foreground = "#99AEB3"
-
-[display.colors.critical]
-background = "#EBA0AC"
-foreground = "#1E1E2E"
 
 [display.border]
 size = 4
 radius = 10
-color = "#000"
 
 [display.image]
 max_size = 64
@@ -104,6 +96,19 @@ margin = { top = 5 }
 [display.body]
 justification = "left"
 margin = { top = 12 }
+
+[[theme]]
+name = "pastel"
+
+[theme.normal]
+background = "#1e1e2e"
+foreground = "#99AEB3"
+border = "#000"
+
+[theme.critical]
+background = "#EBA0AC"
+foreground = "#1E1E2E"
+border = "#000"
 
 [[app]]
 name = "Telegram Desktop"

--- a/crates/backend/src/banner.rs
+++ b/crates/backend/src/banner.rs
@@ -1,4 +1,4 @@
-use std::time;
+use std::{path::PathBuf, time};
 
 use config::{Border, Config, DisplayConfig};
 use dbus::notification::Notification;
@@ -14,8 +14,9 @@ use render::{
         WidgetConfiguration,
     },
 };
+use shared::cached_data::CachedData;
 
-use crate::cache::{CachedLayout, CachedLayouts};
+use crate::cache::CachedLayout;
 
 pub struct BannerRect {
     data: Notification,
@@ -75,7 +76,7 @@ impl BannerRect {
         &mut self,
         font_collection: &FontCollection,
         config: &Config,
-        cached_layouts: &CachedLayouts,
+        cached_layouts: &CachedData<PathBuf, CachedLayout>,
     ) {
         debug!("Banner (id={}): Beginning of draw", self.data.id);
 

--- a/crates/backend/src/banner.rs
+++ b/crates/backend/src/banner.rs
@@ -1,6 +1,9 @@
 use std::{path::PathBuf, time};
 
-use config::{Border, Config, DisplayConfig};
+use config::{
+    display::{Border, DisplayConfig},
+    Config,
+};
 use dbus::notification::Notification;
 use log::{debug, trace};
 
@@ -89,8 +92,8 @@ impl BannerRect {
         let mut drawer = Drawer::new(Bgra::new(), rect_size.clone());
 
         let mut layout = match &display.layout {
-            config::Layout::Default => Self::default_layout(display),
-            config::Layout::FromPath { path_buf } => cached_layouts
+            config::display::Layout::Default => Self::default_layout(display),
+            config::display::Layout::FromPath { path_buf } => cached_layouts
                 .get(path_buf)
                 .and_then(CachedLayout::layout)
                 .cloned()
@@ -103,6 +106,7 @@ impl BannerRect {
             rect_size,
             &WidgetConfiguration {
                 display_config: display,
+                theme: config.theme_by_app(&self.data.app_name),
                 notification: &self.data,
                 font_collection,
                 font_size,

--- a/crates/backend/src/banner.rs
+++ b/crates/backend/src/banner.rs
@@ -100,8 +100,6 @@ impl BannerRect {
                 .unwrap_or_else(|| Self::default_layout(display)),
         };
 
-        let font_size = config.general().font.size as f32;
-
         layout.compile(
             rect_size,
             &WidgetConfiguration {
@@ -109,7 +107,6 @@ impl BannerRect {
                 theme: config.theme_by_app(&self.data.app_name),
                 notification: &self.data,
                 font_collection,
-                font_size,
                 override_properties: display.layout.is_default(),
             },
         );

--- a/crates/backend/src/cache.rs
+++ b/crates/backend/src/cache.rs
@@ -45,10 +45,7 @@ impl<'a> TryFrom<&'a PathBuf> for CachedLayout {
         let watcher = match FilesWatcher::init(vec![path_buf]) {
             Ok(watcher) => watcher,
             Err(err) => {
-                return Err(CachedValueError::FailedInitWatcher {
-                    path_buf: path_buf.to_owned(),
-                    source: err,
-                });
+                return Err(CachedValueError::FailedInitWatcher { source: err });
             }
         };
 

--- a/crates/backend/src/cache.rs
+++ b/crates/backend/src/cache.rs
@@ -1,60 +1,11 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-use log::{error, warn};
+use log::warn;
 use render::widget::Widget;
-use shared::file_watcher::{FileState, FilesWatcher};
-
-pub(super) struct CachedLayouts {
-    layouts: HashMap<PathBuf, CachedLayout>,
-}
-
-impl CachedLayouts {
-    pub(super) fn get(&self, path: &PathBuf) -> Option<&CachedLayout> {
-        self.layouts.get(path)
-    }
-
-    pub(super) fn update(&mut self) {
-        self.layouts
-            .values_mut()
-            .for_each(|layout| match layout.check_updates() {
-                FileState::Updated => layout.update(),
-                FileState::NothingChanged | FileState::NotFound => (),
-            })
-    }
-
-    pub(super) fn extend_by_paths(&mut self, paths: Vec<&PathBuf>) {
-        self.layouts.retain(|path, _| paths.contains(&path));
-
-        for path_buf in paths {
-            if self.layouts.contains_key(path_buf) {
-                continue;
-            }
-
-            if let Some(cached_layout) = CachedLayout::from_path(path_buf) {
-                self.layouts.insert(path_buf.to_owned(), cached_layout);
-            }
-        }
-    }
-}
-
-impl<'a> FromIterator<&'a PathBuf> for CachedLayouts {
-    fn from_iter<T: IntoIterator<Item = &'a PathBuf>>(iter: T) -> Self {
-        let layouts = iter
-            .into_iter()
-            .filter_map(|path_buf| {
-                CachedLayout::from_path(path_buf).map(|cached_layout| (path_buf, cached_layout))
-            })
-            .fold(HashMap::new(), |mut acc, (path_buf, cached_layout)| {
-                acc.insert(path_buf.to_owned(), cached_layout);
-                acc
-            });
-
-        Self { layouts }
-    }
-}
+use shared::{
+    cached_data::{CacheUpdate, CachedValueError},
+    file_watcher::{FileState, FilesWatcher},
+};
 
 pub(super) struct CachedLayout {
     watcher: FilesWatcher,
@@ -62,32 +13,8 @@ pub(super) struct CachedLayout {
 }
 
 impl CachedLayout {
-    fn from_path(path_buf: &PathBuf) -> Option<Self> {
-        let watcher = match FilesWatcher::init(vec![path_buf]) {
-            Ok(watcher) => watcher,
-            Err(err) => {
-                error!("Failed to init watcher for file {path_buf:?}. Error: {err}");
-                return None;
-            }
-        };
-
-        let layout = watcher
-            .get_watching_path()
-            .and_then(CachedLayout::load_layout);
-
-        Some(CachedLayout { watcher, layout })
-    }
-
     pub(super) fn layout(&self) -> Option<&Widget> {
         self.layout.as_ref()
-    }
-
-    fn check_updates(&mut self) -> FileState {
-        self.watcher.check_updates()
-    }
-
-    fn update(&mut self) {
-        self.layout = self.watcher.get_watching_path().and_then(Self::load_layout)
     }
 
     fn load_layout(path: &Path) -> Option<Widget> {
@@ -98,5 +25,37 @@ impl CachedLayout {
                 None
             }
         }
+    }
+}
+
+impl CacheUpdate for CachedLayout {
+    fn check_updates(&mut self) -> FileState {
+        self.watcher.check_updates()
+    }
+
+    fn update(&mut self) {
+        self.layout = self.watcher.get_watching_path().and_then(Self::load_layout)
+    }
+}
+
+impl<'a> TryFrom<&'a PathBuf> for CachedLayout {
+    type Error = CachedValueError;
+
+    fn try_from(path_buf: &'a PathBuf) -> Result<Self, Self::Error> {
+        let watcher = match FilesWatcher::init(vec![path_buf]) {
+            Ok(watcher) => watcher,
+            Err(err) => {
+                return Err(CachedValueError::FailedInitWatcher {
+                    path_buf: path_buf.to_owned(),
+                    source: err,
+                });
+            }
+        };
+
+        let layout = watcher
+            .get_watching_path()
+            .and_then(CachedLayout::load_layout);
+
+        Ok(CachedLayout { watcher, layout })
     }
 }

--- a/crates/backend/src/render.rs
+++ b/crates/backend/src/render.rs
@@ -86,7 +86,8 @@ impl Renderer {
                     FileState::NotFound | FileState::NothingChanged => (),
                 };
 
-                if self.config.update_themes() || self.window_manager.update_cache() {
+                // if self.config.update_themes() || self.window_manager.update_cache() {
+                if self.window_manager.update_cache() {
                     self.window_manager.update_by_config(&self.config)?;
                 }
             }

--- a/crates/backend/src/render.rs
+++ b/crates/backend/src/render.rs
@@ -71,7 +71,7 @@ impl Renderer {
             self.window_manager.dispatch()?;
 
             {
-                match self.config.check_updates() {
+                match self.config.check_display_updates() {
                     FileState::NotFound | FileState::Updated => {
                         self.config.update();
                         self.window_manager.update_by_config(&self.config)?;
@@ -80,7 +80,9 @@ impl Renderer {
                     FileState::NothingChanged => (),
                 };
 
-                self.window_manager.update_cache(&self.config);
+                if self.config.update_themes() || self.window_manager.update_cache() {
+                    self.window_manager.update_by_config(&self.config)?;
+                }
             }
 
             std::thread::sleep(Duration::from_millis(50));

--- a/crates/backend/src/render.rs
+++ b/crates/backend/src/render.rs
@@ -80,7 +80,7 @@ impl Renderer {
                     FileState::NothingChanged => (),
                 };
 
-                self.window_manager.update_cache();
+                self.window_manager.update_cache(&self.config);
             }
 
             std::thread::sleep(Duration::from_millis(50));

--- a/crates/backend/src/window.rs
+++ b/crates/backend/src/window.rs
@@ -156,20 +156,20 @@ impl Window {
         debug!("Window: Reconfigured by updated config");
     }
 
-    fn relocate(&mut self, (x, y): (u8, u8), anchor_cfg: &config::Anchor) {
+    fn relocate(&mut self, (x, y): (u8, u8), anchor_cfg: &config::general::Anchor) {
         if let Some(layer_surface) = self.layer_surface.as_ref() {
             debug!("Window: Relocate to anchor {anchor_cfg:?} with offsets x - {x} and y - {y}");
             self.margin = Margin::from_anchor(x as i32, y as i32, anchor_cfg);
 
             let anchor = match anchor_cfg {
-                config::Anchor::Top => Anchor::Top,
-                config::Anchor::TopLeft => Anchor::Top.union(Anchor::Left),
-                config::Anchor::TopRight => Anchor::Top.union(Anchor::Right),
-                config::Anchor::Bottom => Anchor::Bottom,
-                config::Anchor::BottomLeft => Anchor::Bottom.union(Anchor::Left),
-                config::Anchor::BottomRight => Anchor::Bottom.union(Anchor::Right),
-                config::Anchor::Left => Anchor::Left,
-                config::Anchor::Right => Anchor::Right,
+                config::general::Anchor::Top => Anchor::Top,
+                config::general::Anchor::TopLeft => Anchor::Top.union(Anchor::Left),
+                config::general::Anchor::TopRight => Anchor::Top.union(Anchor::Right),
+                config::general::Anchor::Bottom => Anchor::Bottom,
+                config::general::Anchor::BottomLeft => Anchor::Bottom.union(Anchor::Left),
+                config::general::Anchor::BottomRight => Anchor::Bottom.union(Anchor::Right),
+                config::general::Anchor::Left => Anchor::Left,
+                config::general::Anchor::Right => Anchor::Right,
             };
 
             layer_surface.set_anchor(anchor);
@@ -394,7 +394,7 @@ impl Window {
         vec![0; gap_size]
     }
 
-    fn write_banners_to_buffer(&mut self, anchor: &config::Anchor, gap_buffer: &[u8]) {
+    fn write_banners_to_buffer(&mut self, anchor: &config::general::Anchor, gap_buffer: &[u8]) {
         fn write(buffer: Option<&mut Buffer>, data: &[u8]) {
             unsafe { buffer.unwrap_unchecked() }.push(data);
         }
@@ -564,7 +564,7 @@ impl Margin {
         }
     }
 
-    fn from_anchor(x: i32, y: i32, anchor: &config::Anchor) -> Self {
+    fn from_anchor(x: i32, y: i32, anchor: &config::general::Anchor) -> Self {
         let mut margin = Margin::new();
 
         if anchor.is_top() {

--- a/crates/backend/src/window.rs
+++ b/crates/backend/src/window.rs
@@ -1,5 +1,6 @@
 use indexmap::{indexmap, IndexMap};
 use log::{debug, error, trace};
+use shared::cached_data::CachedData;
 use std::{
     cmp::Ordering,
     fs::File,
@@ -7,6 +8,7 @@ use std::{
         fd::{AsFd, BorrowedFd},
         unix::fs::FileExt,
     },
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -28,7 +30,7 @@ use super::internal_messages::RendererMessage;
 use config::{self, Config};
 use dbus::notification::{self, Notification};
 
-use crate::{banner::BannerRect, cache::CachedLayouts};
+use crate::{banner::BannerRect, cache::CachedLayout};
 use render::{font::FontCollection, types::RectSize};
 
 pub(super) struct Window {
@@ -187,7 +189,7 @@ impl Window {
         &mut self,
         mut notifications: Vec<Notification>,
         config: &Config,
-        cached_layouts: &CachedLayouts,
+        cached_layouts: &CachedData<PathBuf, CachedLayout>,
     ) {
         self.replace_by_indices(&mut notifications, config, cached_layouts);
 
@@ -209,7 +211,7 @@ impl Window {
         &mut self,
         notifications: &mut Vec<Notification>,
         config: &Config,
-        cached_layouts: &CachedLayouts,
+        cached_layouts: &CachedData<PathBuf, CachedLayout>,
     ) {
         let matching_indices: Vec<usize> = notifications
             .iter()
@@ -347,7 +349,7 @@ impl Window {
         &mut self,
         qhandle: &QueueHandle<Window>,
         config: &Config,
-        cached_layouts: &CachedLayouts,
+        cached_layouts: &CachedData<PathBuf, CachedLayout>,
     ) {
         self.banners
             .values_mut()

--- a/crates/backend/src/window_manager.rs
+++ b/crates/backend/src/window_manager.rs
@@ -1,9 +1,11 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use log::debug;
+use shared::cached_data::CachedData;
 use wayland_client::{Connection, EventQueue, QueueHandle};
 
-use super::cache::CachedLayouts;
+use crate::cache::CachedLayout;
+
 use super::internal_messages::RendererMessage;
 use config::Config;
 use dbus::notification::Notification;
@@ -18,7 +20,7 @@ pub(crate) struct WindowManager {
     window: Option<Window>,
 
     font_collection: Arc<FontCollection>,
-    cached_layouts: CachedLayouts,
+    cached_layouts: CachedData<PathBuf, CachedLayout>,
 
     events: Vec<RendererMessage>,
 }
@@ -29,7 +31,7 @@ impl WindowManager {
         let font_collection = Arc::new(FontCollection::load_by_font_name(
             &config.general().font.name,
         )?);
-        let cached_layouts: CachedLayouts = config
+        let cached_layouts = config
             .displays()
             .filter_map(|display| match &display.layout {
                 config::Layout::Default => None,
@@ -52,12 +54,24 @@ impl WindowManager {
         })
     }
 
-    pub(crate) fn update_cache(&mut self) {
-        self.cached_layouts.update();
+    pub(crate) fn update_cache(&mut self, config: &Config) {
+        let updated = self.cached_layouts.update();
+        if updated {
+            if let Some(window) = self.window.as_mut() {
+                let qhandle = unsafe { self.qhandle.as_ref().unwrap_unchecked() };
+
+                window.redraw(qhandle, config, &self.cached_layouts);
+                window.frame(qhandle);
+                window.commit();
+
+            }
+
+            debug!("Window Manager: Updated the layouts")
+        }
     }
 
     pub(crate) fn update_by_config(&mut self, config: &Config) -> anyhow::Result<()> {
-        self.cached_layouts.extend_by_paths(
+        self.cached_layouts.extend_by_keys(
             config
                 .displays()
                 .filter_map(|display| match &display.layout {

--- a/crates/backend/src/window_manager.rs
+++ b/crates/backend/src/window_manager.rs
@@ -34,8 +34,8 @@ impl WindowManager {
         let cached_layouts = config
             .displays()
             .filter_map(|display| match &display.layout {
-                config::Layout::Default => None,
-                config::Layout::FromPath { path_buf } => Some(path_buf),
+                config::display::Layout::Default => None,
+                config::display::Layout::FromPath { path_buf } => Some(path_buf),
             })
             .collect();
 
@@ -54,20 +54,8 @@ impl WindowManager {
         })
     }
 
-    pub(crate) fn update_cache(&mut self, config: &Config) {
-        let updated = self.cached_layouts.update();
-        if updated {
-            if let Some(window) = self.window.as_mut() {
-                let qhandle = unsafe { self.qhandle.as_ref().unwrap_unchecked() };
-
-                window.redraw(qhandle, config, &self.cached_layouts);
-                window.frame(qhandle);
-                window.commit();
-
-            }
-
-            debug!("Window Manager: Updated the layouts")
-        }
+    pub(crate) fn update_cache(&mut self) -> bool {
+        self.cached_layouts.update()
     }
 
     pub(crate) fn update_by_config(&mut self, config: &Config) -> anyhow::Result<()> {
@@ -75,8 +63,8 @@ impl WindowManager {
             config
                 .displays()
                 .filter_map(|display| match &display.layout {
-                    config::Layout::Default => None,
-                    config::Layout::FromPath { path_buf } => Some(path_buf),
+                    config::display::Layout::Default => None,
+                    config::display::Layout::FromPath { path_buf } => Some(path_buf.to_owned()),
                 })
                 .collect(),
         );

--- a/crates/config/src/color.rs
+++ b/crates/config/src/color.rs
@@ -1,56 +1,9 @@
 use std::str::Chars;
 
-use dbus::notification::Urgency;
-use macros::ConfigProperty;
 use serde::Deserialize;
 use shared::value::TryDowncast;
 
 use super::public;
-
-public! {
-    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
-    #[cfg_prop(name(UrgencyColors), derive(Debug))]
-    struct TomlUrgencyColors {
-        #[cfg_prop(use_type(Colors), mergeable)]
-        low: Option<TomlColors>,
-
-        #[cfg_prop(use_type(Colors), mergeable)]
-        normal: Option<TomlColors>,
-
-        #[cfg_prop(use_type(Colors), mergeable, default(TomlColors::default_critical()))]
-        critical: Option<TomlColors>,
-    }
-}
-
-impl UrgencyColors {
-    pub fn by_urgency(&self, urgency: &Urgency) -> &Colors {
-        match urgency {
-            Urgency::Low => &self.low,
-            Urgency::Normal => &self.normal,
-            Urgency::Critical => &self.critical,
-        }
-    }
-}
-
-public! {
-    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
-    #[cfg_prop(name(Colors), derive(Debug))]
-    struct TomlColors {
-        #[cfg_prop(default(Color::new_white()))]
-        background: Option<Color>,
-        #[cfg_prop(default(Color::new_black()))]
-        foreground: Option<Color>,
-    }
-}
-
-impl TomlColors {
-    fn default_critical() -> TomlColors {
-        TomlColors {
-            background: Some(Color::new_white()),
-            foreground: Some(Color::new_red()),
-        }
-    }
-}
 
 public! {
     #[derive(Debug, Clone, Deserialize, Default)]
@@ -73,6 +26,7 @@ impl Color {
         }
     }
 
+    #[allow(unused)]
     pub(super) fn new_black() -> Self {
         Self {
             red: 0,

--- a/crates/config/src/display.rs
+++ b/crates/config/src/display.rs
@@ -1,0 +1,190 @@
+use std::path::PathBuf;
+
+use macros::{ConfigProperty, GenericBuilder};
+use serde::Deserialize;
+use shared::{error::ConversionError, value::TryDowncast};
+
+use crate::{
+    public,
+    spacing::Spacing,
+    text::{TextProperty, TomlTextProperty},
+};
+
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(name(DisplayConfig), derive(Debug))]
+    struct TomlDisplayConfig {
+        layout: Option<Layout>,
+
+        theme: Option<String>,
+
+        #[cfg_prop(use_type(ImageProperty), mergeable)]
+        image: Option<TomlImageProperty>,
+
+        padding: Option<Spacing>,
+        #[cfg_prop(use_type(Border), mergeable)]
+        border: Option<TomlBorder>,
+
+        #[cfg_prop(temporary)]
+        text: Option<TomlTextProperty>,
+
+        #[cfg_prop(inherits(field = text), use_type(TextProperty), default(TomlTextProperty::default_title()), mergeable)]
+        title: Option<TomlTextProperty>,
+
+        #[cfg_prop(inherits(field = text), use_type(TextProperty), mergeable)]
+        body: Option<TomlTextProperty>,
+
+        #[cfg_prop(default(true))]
+        markup: Option<bool>,
+
+        #[cfg_prop(default(0))]
+        timeout: Option<u16>,
+    }
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(from = "String")]
+pub enum Layout {
+    #[default]
+    Default,
+    FromPath {
+        path_buf: PathBuf,
+    },
+}
+
+impl Layout {
+    pub fn is_default(&self) -> bool {
+        matches!(self, Layout::Default)
+    }
+}
+
+impl From<String> for Layout {
+    fn from(value: String) -> Self {
+        if value == "default" {
+            return Layout::Default;
+        }
+
+        Layout::FromPath {
+            path_buf: PathBuf::from(
+                shellexpand::full(&value)
+                    .map(|value| value.into_owned())
+                    .unwrap_or(value),
+            ),
+        }
+    }
+}
+
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(
+        name(ImageProperty),
+        derive(GenericBuilder, Debug, Clone),
+        attributes(#[gbuilder(name(GBuilderImageProperty))])
+    )]
+    struct TomlImageProperty {
+        #[cfg_prop(
+            default(64),
+            attributes(#[gbuilder(default(64))])
+        )]
+        max_size: Option<u16>,
+
+        #[cfg_prop(
+            default(0),
+            attributes(#[gbuilder(default(0))])
+        )]
+        rounding: Option<u16>,
+
+        #[cfg_prop(attributes(#[gbuilder(default)]))]
+        margin: Option<Spacing>,
+
+        #[cfg_prop(attributes(#[gbuilder(default)]))]
+        resizing_method: Option<ResizingMethod>,
+    }
+}
+
+impl Default for ImageProperty {
+    fn default() -> Self {
+        TomlImageProperty::default().into()
+    }
+}
+
+impl TryFrom<shared::value::Value> for ImageProperty {
+    type Error = shared::error::ConversionError;
+
+    fn try_from(value: shared::value::Value) -> Result<Self, Self::Error> {
+        match value {
+            shared::value::Value::Any(dyn_value) => dyn_value.try_downcast(),
+            _ => Err(shared::error::ConversionError::CannotConvert),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub enum ResizingMethod {
+    #[serde(rename = "nearest")]
+    Nearest,
+    #[serde(rename = "triangle")]
+    Triangle,
+    #[serde(rename = "catmull-rom")]
+    CatmullRom,
+    #[default]
+    #[serde(rename = "gaussian")]
+    Gaussian,
+    #[serde(rename = "lanczos3")]
+    Lanczos3,
+}
+
+impl TryFrom<shared::value::Value> for ResizingMethod {
+    type Error = shared::error::ConversionError;
+
+    fn try_from(value: shared::value::Value) -> Result<Self, Self::Error> {
+        match value {
+            shared::value::Value::String(str) => Ok(match str.to_lowercase().as_str() {
+                "nearest" => ResizingMethod::Nearest,
+                "triangle" => ResizingMethod::Triangle,
+                "catmull-rom" | "catmull_rom" => ResizingMethod::CatmullRom,
+                "gaussian" => ResizingMethod::Gaussian,
+                "lanczos3" => ResizingMethod::Lanczos3,
+                _ => Err(shared::error::ConversionError::InvalidValue {
+                    expected: "nearest, triangle, gaussian, lanczos3, catmull-rom or catmull_rom",
+                    actual: str,
+                })?,
+            }),
+            shared::value::Value::Any(dyn_value) => dyn_value.try_downcast(),
+            _ => Err(shared::error::ConversionError::CannotConvert),
+        }
+    }
+}
+
+public! {
+    #[derive(ConfigProperty, Debug, Deserialize, Default, Clone)]
+    #[cfg_prop(
+        name(Border),
+        derive(GenericBuilder, Debug, Clone, Default),
+        attributes(#[gbuilder(name(GBuilderBorder))])
+    )]
+    struct TomlBorder {
+        #[cfg_prop(
+            default(0),
+            attributes(#[gbuilder(default(0))])
+        )]
+        size: Option<u8>,
+
+        #[cfg_prop(
+            default(0),
+            attributes(#[gbuilder(default(0))])
+        )]
+        radius: Option<u8>,
+    }
+}
+
+impl TryFrom<shared::value::Value> for Border {
+    type Error = ConversionError;
+
+    fn try_from(value: shared::value::Value) -> Result<Self, Self::Error> {
+        match value {
+            shared::value::Value::Any(dyn_value) => dyn_value.try_downcast(),
+            _ => Err(ConversionError::CannotConvert),
+        }
+    }
+}

--- a/crates/config/src/display.rs
+++ b/crates/config/src/display.rs
@@ -25,7 +25,7 @@ public! {
         #[cfg_prop(use_type(Border), mergeable)]
         border: Option<TomlBorder>,
 
-        #[cfg_prop(temporary)]
+        #[cfg_prop(temporary, mergeable)]
         text: Option<TomlTextProperty>,
 
         #[cfg_prop(inherits(field = text), use_type(TextProperty), default(TomlTextProperty::default_title()), mergeable)]

--- a/crates/config/src/general.rs
+++ b/crates/config/src/general.rs
@@ -29,16 +29,15 @@ public! {
 
 public! {
     #[derive(Debug, Deserialize, Clone)]
-    #[serde(from = "(String, u8)")]
+    #[serde(from = "String")]
     struct Font {
         name: String,
-        size: u8,
     }
 }
 
-impl From<(String, u8)> for Font {
-    fn from((name, size): (String, u8)) -> Self {
-        Font { name, size }
+impl From<String> for Font {
+    fn from(name: String) -> Self {
+        Font { name }
     }
 }
 
@@ -46,7 +45,6 @@ impl Default for Font {
     fn default() -> Self {
         Font {
             name: "Noto Sans".to_string(),
-            size: 12,
         }
     }
 }

--- a/crates/config/src/general.rs
+++ b/crates/config/src/general.rs
@@ -1,0 +1,114 @@
+//! The module that contain the structure `GeneralConfig` which stores general config properties.
+//!
+//! With it the module also stores `TomlGeneralConfig` which can parse data from TOML data.
+
+use macros::ConfigProperty;
+use serde::Deserialize;
+
+use crate::{public, sorting::Sorting};
+
+public! {
+    #[derive(ConfigProperty, Default, Debug, Deserialize, Clone)]
+    #[cfg_prop(name(GeneralConfig), derive(Debug))]
+    struct TomlGeneralConfig {
+        font: Option<Font>,
+
+        #[cfg_prop(default(300))]
+        width: Option<u16>,
+        #[cfg_prop(default(150))]
+        height: Option<u16>,
+
+        anchor: Option<Anchor>,
+        offset: Option<(u8, u8)>,
+        #[cfg_prop(default(10))]
+        gap: Option<u8>,
+
+        sorting: Option<Sorting>,
+    }
+}
+
+public! {
+    #[derive(Debug, Deserialize, Clone)]
+    #[serde(from = "(String, u8)")]
+    struct Font {
+        name: String,
+        size: u8,
+    }
+}
+
+impl From<(String, u8)> for Font {
+    fn from((name, size): (String, u8)) -> Self {
+        Font { name, size }
+    }
+}
+
+impl Default for Font {
+    fn default() -> Self {
+        Font {
+            name: "Noto Sans".to_string(),
+            size: 12,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(from = "String")]
+pub enum Anchor {
+    Top,
+    TopLeft,
+    #[default]
+    TopRight,
+    Bottom,
+    BottomLeft,
+    BottomRight,
+    Left,
+    Right,
+}
+
+impl Anchor {
+    pub fn is_top(&self) -> bool {
+        matches!(self, Anchor::Top | Anchor::TopLeft | Anchor::TopRight)
+    }
+
+    pub fn is_right(&self) -> bool {
+        matches!(self, Anchor::TopRight | Anchor::BottomRight | Anchor::Right)
+    }
+
+    pub fn is_bottom(&self) -> bool {
+        matches!(
+            self,
+            Anchor::Bottom | Anchor::BottomLeft | Anchor::BottomRight
+        )
+    }
+
+    pub fn is_left(&self) -> bool {
+        matches!(self, Anchor::TopLeft | Anchor::BottomLeft | Anchor::Left)
+    }
+}
+
+impl From<String> for Anchor {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "top" => Anchor::Top,
+            "top-left" | "top left" => Anchor::TopLeft,
+            "top-right" | "top right" => Anchor::TopRight,
+            "bottom" => Anchor::Bottom,
+            "bottom-left" | "bottom left" => Anchor::BottomLeft,
+            "bottom-right" | "bottom right" => Anchor::BottomRight,
+            "left" => Anchor::Left,
+            "right" => Anchor::Right,
+            other => panic!(
+                "Invalid anchor option! There are possible values:\n\
+                - \"top\"\n\
+                - \"top-right\" or \"top right\"\n\
+                - \"top-left\" or \"top left\"\n\
+                - bottom\n\
+                - \"bottom-right\" or \"bottom right\"\n\
+                - \"bottom-left\" or \"bottom left\"\n\
+                - left\n\
+                - right\n\
+                Used: {other}"
+            ),
+        }
+    }
+}

--- a/crates/config/src/text.rs
+++ b/crates/config/src/text.rs
@@ -30,6 +30,9 @@ public! {
         #[cfg_prop(attributes(#[gbuilder(default)]))]
         justification: Option<TextJustification>,
 
+        #[cfg_prop(default(12))]
+        font_size: Option<u8>,
+
         #[cfg_prop(
             default(0),
             attributes(#[gbuilder(default(0))])

--- a/crates/config/src/theme.rs
+++ b/crates/config/src/theme.rs
@@ -1,0 +1,57 @@
+use dbus::notification::Urgency;
+use macros::ConfigProperty;
+use serde::Deserialize;
+
+use crate::{color::Color, public};
+
+public! {
+    #[derive(ConfigProperty, Deserialize, Default)]
+    #[cfg_prop(name(Theme))]
+    struct TomlTheme {
+        #[cfg_prop(use_type(Colors))]
+        low: Option<TomlColors>,
+
+        #[cfg_prop(use_type(Colors))]
+        normal: Option<TomlColors>,
+
+        #[cfg_prop(use_type(Colors), default(path = TomlColors::default_critical))]
+        critical: Option<TomlColors>,
+    }
+}
+
+impl Theme {
+    pub fn by_urgency(&self, urgency: &Urgency) -> &Colors {
+        match urgency {
+            Urgency::Low => &self.low,
+            Urgency::Normal => &self.normal,
+            Urgency::Critical => &self.critical,
+        }
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        TomlTheme::default().unwrap_or_default()
+    }
+}
+
+public! {
+    #[derive(ConfigProperty, Clone, Default, Deserialize)]
+    #[cfg_prop(name(Colors))]
+    struct TomlColors {
+        foreground: Option<Color>,
+        background: Option<Color>,
+
+        border: Option<Color>,
+    }
+}
+
+impl TomlColors {
+    fn default_critical() -> TomlColors {
+        TomlColors {
+            background: Some(Color::new_white()),
+            foreground: Some(Color::new_red()),
+            border: Some(Color::new_red()),
+        }
+    }
+}

--- a/crates/config/src/theme.rs
+++ b/crates/config/src/theme.rs
@@ -5,9 +5,11 @@ use serde::Deserialize;
 use crate::{color::Color, public};
 
 public! {
-    #[derive(ConfigProperty, Deserialize, Default)]
-    #[cfg_prop(name(Theme))]
+    #[derive(ConfigProperty, Deserialize, Default, Debug)]
+    #[cfg_prop(name(Theme), derive(Debug))]
     struct TomlTheme {
+        name: Option<String>,
+
         #[cfg_prop(use_type(Colors))]
         low: Option<TomlColors>,
 
@@ -36,12 +38,15 @@ impl Default for Theme {
 }
 
 public! {
-    #[derive(ConfigProperty, Clone, Default, Deserialize)]
-    #[cfg_prop(name(Colors))]
+    #[derive(ConfigProperty, Clone, Default, Deserialize, Debug)]
+    #[cfg_prop(name(Colors), derive(Debug))]
     struct TomlColors {
+        #[cfg_prop(default(path = Color::new_black))]
         foreground: Option<Color>,
+        #[cfg_prop(default(path = Color::new_white))]
         background: Option<Color>,
 
+        #[cfg_prop(default(path = Color::new_black))]
         border: Option<Color>,
     }
 }

--- a/crates/filetype/src/converter.rs
+++ b/crates/filetype/src/converter.rs
@@ -1,8 +1,8 @@
 use anyhow::bail;
 use config::{
+    display::{Border, GBuilderBorder, GBuilderImageProperty, ImageProperty},
     spacing::{GBuilderSpacing, Spacing},
     text::{GBuilderTextProperty, TextProperty},
-    Border, GBuilderBorder, GBuilderImageProperty, ImageProperty,
 };
 use log::warn;
 use pest::iterators::{Pair, Pairs};

--- a/crates/render/src/color.rs
+++ b/crates/render/src/color.rs
@@ -1,6 +1,6 @@
 use std::ops::{Mul, MulAssign};
 
-use config::colors::Color;
+use config::color::Color;
 
 use super::widget::Coverage;
 

--- a/crates/render/src/image.rs
+++ b/crates/render/src/image.rs
@@ -1,7 +1,7 @@
 use log::{debug, warn};
 use owned_ttf_parser::{RasterGlyphImage, RasterImageFormat};
 
-use config::{ImageProperty, ResizingMethod};
+use config::display::{ImageProperty, ResizingMethod};
 use dbus::image::ImageData;
 
 use crate::{drawer::Drawer, types::RectSize};

--- a/crates/render/src/image.rs
+++ b/crates/render/src/image.rs
@@ -151,6 +151,10 @@ impl Image {
     }
 
     pub fn from_svg(image_path: &str, image_property: &ImageProperty, max_size: &RectSize) -> Self {
+        if image_path.is_empty() {
+            return Image::Unknown;
+        }
+
         let data = match std::fs::read(image_path) {
             Ok(data) => data,
             Err(err) => {

--- a/crates/render/src/widget.rs
+++ b/crates/render/src/widget.rs
@@ -127,7 +127,6 @@ pub struct WidgetConfiguration<'a> {
     pub notification: &'a Notification,
     pub font_collection: &'a FontCollection,
     pub theme: &'a Theme,
-    pub font_size: f32,
     pub display_config: &'a DisplayConfig,
     pub override_properties: bool,
 }
@@ -717,7 +716,6 @@ impl WText {
         WidgetConfiguration {
             display_config,
             notification,
-            font_size,
             font_collection,
             override_properties,
             theme,
@@ -747,12 +745,13 @@ impl WText {
             }
         };
 
+        let px_size = self.property.font_size as f32;
         let mut content = match notification_content {
             NotificationContent::Text(text) => {
-                TextRect::from_text(text, *font_size, &self.property.style, font_collection)
+                TextRect::from_text(text, px_size, &self.property.style, font_collection)
             }
             NotificationContent::String(str) => {
-                TextRect::from_str(str, *font_size, &self.property.style, font_collection)
+                TextRect::from_str(str, px_size, &self.property.style, font_collection)
             }
         };
 

--- a/crates/shared/src/cached_data.rs
+++ b/crates/shared/src/cached_data.rs
@@ -1,0 +1,88 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use log::error;
+
+use crate::file_watcher::FileState;
+
+pub struct CachedData<K, V>(HashMap<K, V>)
+where
+    K: std::cmp::Eq + std::hash::Hash,
+    V: for<'a> TryFrom<&'a K, Error = CachedValueError>;
+
+impl<K, V> CachedData<K, V>
+where
+    K: std::cmp::Eq + std::hash::Hash + ToOwned<Owned = K>,
+    V: for<'a> TryFrom<&'a K, Error = CachedValueError>,
+{
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.0.get(key)
+    }
+
+    pub fn update(&mut self) -> bool
+    where
+        V: CacheUpdate,
+    {
+        let mut updated = false;
+        self.0
+            .values_mut()
+            .for_each(|value| match value.check_updates() {
+                FileState::Updated => {
+                    value.update();
+                    updated = true
+                }
+                FileState::NothingChanged | FileState::NotFound => (),
+            });
+        updated
+    }
+
+    pub fn extend_by_keys(&mut self, keys: Vec<&K>) {
+        self.0.retain(|key, _| keys.contains(&key));
+
+        for key in keys {
+            if self.0.contains_key(key) {
+                continue;
+            }
+
+            match V::try_from(key) {
+                Ok(data) => {
+                    self.0.insert(key.to_owned(), data);
+                }
+                Err(err) => {
+                    error!("{err}")
+                }
+            }
+        }
+    }
+}
+
+impl<'a, K, V> FromIterator<&'a K> for CachedData<K, V>
+where
+    K: std::cmp::Eq + std::hash::Hash + ToOwned<Owned = K>,
+    V: for<'b> TryFrom<&'b K, Error = CachedValueError>,
+{
+    fn from_iter<T: IntoIterator<Item = &'a K>>(iter: T) -> Self {
+        let data = iter
+            .into_iter()
+            .filter_map(|key| V::try_from(key).map(|value| (key, value)).ok())
+            .fold(HashMap::new(), |mut acc, (key, value)| {
+                acc.insert(key.to_owned(), value);
+                acc
+            });
+
+        Self(data)
+    }
+}
+
+pub trait CacheUpdate {
+    fn check_updates(&mut self) -> FileState;
+    fn update(&mut self);
+}
+
+#[derive(derive_more::Display)]
+pub enum CachedValueError {
+    #[display("Failed to init file watcher for file {path_buf:?}. Error: {source}")]
+    FailedInitWatcher {
+        path_buf: PathBuf,
+        source: anyhow::Error,
+    },
+}

--- a/crates/shared/src/file_watcher.rs
+++ b/crates/shared/src/file_watcher.rs
@@ -21,6 +21,11 @@ impl FilesWatcher {
     /// The paths are **arranged**. It's means that first path is more prioritized than second and
     /// second is more prioritized than third and so on.
     pub fn init<T: AsRef<Path>>(paths: Vec<T>) -> anyhow::Result<Self> {
+        assert!(
+            !paths.is_empty(),
+            "At least one path should be provided to FilesWatcher"
+        );
+
         debug!("Watcher: Initializing");
         let inotify = Inotify::init()?;
 

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod error;
 pub mod file_watcher;
 pub mod value;
+pub mod cached_data;

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,4 +1,4 @@
+pub mod cached_data;
 pub mod error;
 pub mod file_watcher;
 pub mod value;
-pub mod cached_data;

--- a/docs/ConfigProperties.md
+++ b/docs/ConfigProperties.md
@@ -321,6 +321,7 @@ The `Text` table:
 | margin        | The text spacing from edges of remaining area                                                                                                                                               | `Spacing` |       0       |
 | justification | The text justification. Possible values: "left", "right", "center", "space-between"                                                                                                         | `String`  |    "left"     |
 | line_spacing  | The gap between wrapped text lines. Measures in px                                                                                                                                          | `u8`      |       0       |
+| font_size     | The size of font. Measures in px                                                                                                                                                            | `u8`      |      12       |
 
 For more explanation how the text draws, please visit [the other documentation about text](BannerLayout.md#text).
 

--- a/docs/ConfigProperties.md
+++ b/docs/ConfigProperties.md
@@ -264,8 +264,8 @@ margin = 5
 ### Image
 
 Usually the notification can contain the image or icon and it draws at the right of
-banner. More about it in [banner layout](BannerLayout.md#image). Our application can
-perform some actions which in result the image will look very pleasant for most users.
+banner. More about it in [banner layout](BannerLayout.md#image). The `Noti` application 
+can perform some actions which in result the image will look very pleasant for most users.
 
 Here's a table of `Image` properties:
 

--- a/docs/ConfigProperties.md
+++ b/docs/ConfigProperties.md
@@ -393,7 +393,7 @@ border = "#0F0" # green border for normal urgency
 border = "#F0F" # pink border for critical urgency
 ```
 
----;
+---
 
 ## Apps
 

--- a/docs/ConfigProperties.md
+++ b/docs/ConfigProperties.md
@@ -1,20 +1,22 @@
 # Config Properties
 
-The Noti application have a way to configure notification banners by TOML config file which placed
+The Noti application have a way to be configured by TOML config file which placed
 at specific position. Here a priority of positions:
 
 1. `$XDG_CONFIG_HOME/noti/config.toml`
 2. `$HOME/.config/noti/config.toml`
 
-Use this file as documentation for all properties.
+Use this file as the specification of configuration properties.
 
 > [!NOTE]
 > Don't need to reload the application after changing config properties because it have
 > `hot-reload` or `watch-mode`.
 
+## Types
+
 Before of all properties, need to understand a few primitive type. The complex types like array or table will be explained in place.
 
-| Type     | Explanation                                                                                                                                                                                                          |
+| Type     | Description                                                                                                                                                                                                          |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `bool`   | A boolean value                                                                                                                                                                                                      |
 | `u8`     | An unsigned integer of 8 bit                                                                                                                                                                                         |
@@ -23,51 +25,84 @@ Before of all properties, need to understand a few primitive type. The complex t
 | `[..]`   | Array containing various type. Used as tuple                                                                                                                                                                         |
 | `Color`  | The hex value which is started by hashtag (#) and wrapped by doubled quotes (defines as string). It can have three, six or eight symbols which represent RGB (including alpha-channel in 8-symboled hex as opacity). |
 
-The documentation have three main sections of application which is showed below as list.
+## Importing
+
+You can move part of configuration values into other files and import them in
+main configuration files by keyword `use` and accepts array of strings. Accepts
+any valid path except relative, including path that contains environment
+variables, starting with tilde.
+
+The syntax:
+
+```toml
+use = [
+    "$XDG_CONFIG_HOME/noti/other_cfg_file.toml",
+    "~/.config/noti/special_cfg_file.toml",
+    "/home/bebra/.config/super-sepcial-file.toml",
+
+    # The relative path is not supported
+    # "./apps/Spotify.toml"
+    # "apps/Spotify.toml"
+]
+```
+
+> [!TIP]
+> Importing the same file more than one time is discouraged and, please, avoid
+> this.
+
+### Config priority
+
+Main thought - current configuration file is more prioritized than imported config file.
+
+So, if the same configuration properties declares twice - in current configuration file and
+in imported file, the application will pick the value from the **current** configuration file.
+
+And, please, avoid any ambiguity in configuration files. The application will try to merge
+these configuration values, but the `Noti` developers won't guarantee that it will work in
+that way as you expected. Instead of this, we recommend declare whole thing in one place
+and import it. For example, you can declare [themes](#themes) in other files and import them
+into main config file.
+
+---
+
+## Property groups
+
+There is four groups of properties:
 
 - [General](#general)
 - [Display](#display)
+- [Themes](#themes)
 - [Apps](#apps)
 
-You can pick any section for begin. We recommend you to go to through from the first one to the last.
-In definitions we may put the link to other property or other definition when we assuming that it is need.
+Each of them belongs to specific idea. So the reading order is not matter. But we recommend you
+to go to through from the first one to the last one.
+
+---
 
 ## General
 
 The 'general' word means that it applies to application or all banners together. Here a table of possible general properties and below we'll go through all properties.
 
-| Property name       | Type                  |  Default value  |
-| :------------------ | :-------------------- | :-------------: |
-| [font](#font)       | `[String, u8]`        | "Noto Sans", 12 |
-| [width](#width)     | `u16`                 |       300       |
-| [height](#height)   | `u16`                 |       150       |
-| [anchor](#anchor)   | `String`              |   "top right"   |
-| [gap](#gap)         | `u8`                  |       10        |
-| [offset](#offset)   | `[u8, u8]`            |     [0, 0]      |
-| [sorting](#sorting) | `String` or `Sorting` |    "default"    |
+| Property name       | Description                                         | Type                  | Default value |
+| :------------------ | :-------------------------------------------------- | :-------------------- | :-----------: |
+| [font](#font)       | [See desc](#font)                                   | `String`              |  "Noto Sans"  |
+| [width](#width)     | The width of banner frame.                          | `u16`                 |      300      |
+| [height](#height)   | The height of banner frame.                         | `u16`                 |      150      |
+| [anchor](#anchor)   | [See desc](#anchor)                                 | `String`              |  "top right"  |
+| [gap](#gap)         | The space size between two banners. Measures in px. | `u8`                  |      10       |
+| [offset](#offset)   | [See desc](#offset)                                 | `[u8, u8]`            |    [0, 0]     |
+| [sorting](#sorting) | [See desc](#sorting)                                | `String` or `Sorting` |   "default"   |
 
 ### Font
 
-The first value of array is the font name. You can write it with or without spaces.
-The application can use only the font name which can be used as pattern in `fc-list` command.
-So you can't use already styled font like "Noto Sans Bold". But the application internally
-can load font with needed styles if it is possible.
-
-The second value of array is the font size in `px`.
-
-### Width
-
-The banner frame width. Currently it is fixed for all banners.
-
-### Height
-
-The banner frame height. Currently it is fixed for all banners.
+Accepts the font name. It can be separated or not by spaces. The application can use only the font
+name which can be used as pattern in `fc-list` command. So you can't use already styled font like
+"Noto Sans Bold". But the application internally can load font with needed styles if it is possible.
 
 ### Anchor
 
-The anchor of current monitor for current window instance.
-It means where you want to see appearing notification banners.
-The possible values:
+The anchor of current monitor for current window instance. It means where you want to see appearing
+notification banners. The possible values:
 
 - `"top"`
 - `"top-left"` or `"top left"`
@@ -80,8 +115,8 @@ The possible values:
 
 ### Offset
 
-The offset from edges for window instance.
-The first value is the offset by x-axis, the second value about y-axis.
+The offset from edges for window instance. The first value is the offset
+by x-axis, the second value - by y-axis.
 
 For example, you picked `"bottom-left"` anchor and `[5, 10]` offset and
 it means that the window instance will be placed at bottom-left edge of a
@@ -104,7 +139,8 @@ Possible values of the `by` property name:
 
 - "default" (alias to "time")
 - "time"
-- "id" (means the notification id, simple to "time", but in replacement it stays in old place)
+- "id" (means the notification id, simple to "time", but in replacement case
+  it stays in old place)
 - "urgency"
 
 Possible values of the `ordering` property name:
@@ -126,37 +162,39 @@ that was made specifically for it.
 The display properties affects only and only for a banner, not the window entire.
 The currently possible properties of `display` table:
 
-| Property name                  | Type                                                                    | Default value |
-| :----------------------------- | :---------------------------------------------------------------------- | :-----------: |
-| [image](#image)                | `Image`                                                                 |       -       |
-| [padding](#padding-and-margin) | `u8` or `[u8, u8]` or `[u8, u8, u8]` or `[u8, u8, u8, u8]` or `Spacing` |       0       |
-| [border](#border)              | `Border`                                                                |       -       |
-| [colors](#colors)              | `UrgencyColors`                                                         |       -       |
-| [text](#text)                  | `Text`                                                                  |       -       |
-| [title](#text)                 | `Text`                                                                  |       -       |
-| [body](#text)                  | `Text`                                                                  |       -       |
-| [markup](#markup)              | `bool`                                                                  |     true      |
-| [timeout](#timeout)            | `u16`                                                                   |       0       |
+| Property name                  | Description                                         | Type                                                                    | Default value |
+| :----------------------------- | :-------------------------------------------------- | :---------------------------------------------------------------------- | :-----------: |
+| [theme](#themes)               | Use the [theme](#themes) by name                    | `String`                                                                |       -       |
+| [image](#image)                | Image properties                                    | `Image`                                                                 |       -       |
+| [padding](#padding-and-margin) | The spacing from the banner's edge to inner content | `u8` or `[u8, u8]` or `[u8, u8, u8]` or `[u8, u8, u8, u8]` or `Spacing` |       0       |
+| [border](#border)              | Border properties                                   | `Border`                                                                |       -       |
+| [text](#text)                  | Text properties (alias for `title` and `body`)      | `Text`                                                                  |       -       |
+| [title](#text)                 | Title text properties                               | `Text`                                                                  |       -       |
+| [body](#text)                  | Body text properties                                | `Text`                                                                  |       -       |
+| [markup](#markup)              | Enables HTML style markup                           | `bool`                                                                  |     true      |
+| [timeout](#timeout)            | Sets the timeout of banner                          | `u16`                                                                   |       0       |
 
 The `Spacing` table:
 
-| Key        | Type | Short description                                                           |
-| :--------- | :--- | :-------------------------------------------------------------------------- |
-| top        | `u8` | Spacing from top                                                            |
-| right      | `u8` | Spacing from right                                                          |
-| bottom     | `u8` | Spacing from bottom                                                         |
-| left       | `u8` | Spacing from left                                                           |
-| vertical   | `u8` | Spacing from top and bottom together (incompatible with top or bottom keys) |
-| horizontal | `u8` | Spacing from left and right together (incompatible with left or right keys) |
+| Key        | Short description                                                           | Type |
+| :--------- | :-------------------------------------------------------------------------- | :--- |
+| top        | Spacing from top                                                            | `u8` |
+| right      | Spacing from right                                                          | `u8` |
+| bottom     | Spacing from bottom                                                         | `u8` |
+| left       | Spacing from left                                                           | `u8` |
+| vertical   | Spacing from top and bottom together (incompatible with top or bottom keys) | `u8` |
+| horizontal | Spacing from left and right together (incompatible with left or right keys) | `u8` |
 
 ### Padding and margin
 
 Within scope of this application, the padding and margin have different meaning.
-The padding is the offset from the banner edges for inner elements, it's like giving the content area smaller.
-The margin is the offset from the edges of remaining area and other inner elements.
+The padding is the spacing from the banner edges for inner elements, it's like giving the content area smaller.
+The margin is the spacing from the edges of remaining area and other inner elements.
 
 > [!NOTE]
-> If you have issue that the image or the text doesn't show in banner, it's maybe because of large value of padding or margins that the content can't fit into remaining space.
+> If you have issue that the image or the text doesn't show in banner, it's maybe
+> because of large value of padding or margins that the content can't fit into
+> remaining space.
 
 Here are two ways to declare properties for the padding and the margins:
 
@@ -233,20 +271,20 @@ pleasant for most users.
 
 Here a table of `Image` properties:
 
-| Property name   | Type                                                                    | Default value | Description                                                                                                                                  |
-| :-------------- | :---------------------------------------------------------------------- | :-----------: | :------------------------------------------------------------------------------------------------------------------------------------------- |
-| max_size        | `u16`                                                                   |      64       | Sets the max size for image and resizes it when width or height exceeds `max_size`                                                           |
-| rounding        | `u16`                                                                   |       0       | It's a border-radius in CSS and used to round image corners                                                                                  |
-| margin          | `u8` or `[u8, u8]` or `[u8, u8, u8]` or `[u8, u8, u8, u8]` or `Spacing` |       0       | Creates a spacing around image. **NOTE: It may be suppressed when an available space is not enough**                                         |
-| resizing_method | `String`                                                                |  "gaussian"   | Sets the resizing method for image when it exceeds `max_size`. Possible values: "gaussian", "nearest", "triandle", "catmull-rom", "lanczos3" |
+| Property name   | Description                                                                                                                                            | Type                                                                    | Default value |
+| :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :-----------: |
+| max_size        | Sets the max size for image and resizes it when width or height of image exceeds `max_size` value                                                      | `u16`                                                                   |      64       |
+| rounding        | It's a border-radius in CSS and used to round image corners                                                                                            | `u16`                                                                   |       0       |
+| margin          | Creates a spacing around image. If there is no space for image, the image will be squished.                                                            | `u8` or `[u8, u8]` or `[u8, u8, u8]` or `[u8, u8, u8, u8]` or `Spacing` |       0       |
+| resizing_method | Sets the resizing method for image when it exceeds `max_size`. Possible values: `"gaussian"`, `"nearest"`, `"triandle"`, `"catmull-rom"`, `"lanczos3"` | `String`                                                                |  "gaussian"   |
 
 ### Border
 
-To notification banner you can apply border styles: border size, radius and color.
+To notification banner you can apply border styles: border size and radius.
 
-- Border size - the width of stroke which is outlines around the banner. It draws in the rectangle, so the inner elements can overlay the border if you pick margin smaller than border size.
+- Border size - the width of stroke which is outlines around the banner.
+  It also reduces inner space of rectange.
 - Border radius - the radius which will applied for rounding the corners of banner.
-- Border color - the color of stroke.
 
 > [!NOTE]
 > You can find that the behavior of banner rounding is different from other applications.
@@ -255,38 +293,17 @@ To notification banner you can apply border styles: border size, radius and colo
 
 The `Border` table:
 
-| Key    | Type    | Default value | Short description                                      |
-| :----- | :------ | :-----------: | :----------------------------------------------------- |
-| size   | `u8`    |       0       | The width of stroke which is outlines around the banne |
-| radius | `u8`    |       0       | The border radius for corner rounding                  |
-| color  | `Color` |   "#000000"   | The stroke color                                       |
-
-### Colors
-
-A notification have three urgencies: low, normal and critical. And you can define
-colors for all them separately.
-
-The `UrgencyColors` table:
-
-| Key      | Type     |                   Default value                    | Short description                        |
-| :------- | :------- | :------------------------------------------------: | :--------------------------------------- |
-| low      | `Colors` | { background = "#FFFFFF", foreground = "#000000" } | The colors for 'low' urgency banner      |
-| normal   | `Colors` | { background = "#FFFFFF", foreground = "#000000" } | The colors for 'normal' urgency banner   |
-| critical | `Colors` | { background = "#FFFFFF", foreground = "#FF0000" } | The colors for 'critical' urgency banner |
-
-The `Colors` table:
-
-| Key        | Type    | Default value | Short description                        |
-| :--------- | :------ | :-----------: | :--------------------------------------- |
-| background | `Color` |   "#FFFFFF"   | The background color of banner           |
-| foreground | `Color` |   "#000000"   | The foreground color which used for text |
+| Key    | Short description                                      | Type | Default value |
+| :----- | :----------------------------------------------------- | :--- | :-----------: |
+| size   | The width of stroke which is outlines around the banne | `u8` |       0       |
+| radius | The border radius for corner rounding                  | `u8` |       0       |
 
 ### Text
 
-Currently our application have only title and body, but they are interpreted as `Text` so they both described here.
-Also introduced a property `text` which can be used for title and body. The idiomatic way tells use `text` when
-you want to define the same values for `title` and `body`, otherwise define values in `title` or `body`. It means
-`title` and `body` **inherits** from `text` property.
+Currently the `Noti` application have only title and body, but they are interpreted as `Text` so they both
+are described here. Also the `text` property was introduced which can be used for title and body at the same
+time. The idiomatic way is using `text` when you want to define the same values for `title` and `body`,
+otherwise define values in `title` or `body`. It means `title` and `body` **inherits** from `text` property.
 
 Priority of properties:
 
@@ -296,14 +313,14 @@ Priority of properties:
 
 The `Text` table:
 
-| Key           | Type      | Default value | Short description                                                                                                                                                                           |
-| :------------ | :-------- | :-----------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| wrap          | `bool`    |     true      | Sets possibility to line breaking when text overflows a line                                                                                                                                |
-| ellipsize_at  | `String`  |     "end"     | Ellipsizes a text if it's totally overflows an area. Possible values: "end" and "middle". "end" - put ellipsis at end of word, "middle" - cut word at some middle of word and puts ellipsis |
-| style         | `String`  |   "regular"   | Sets the style for whole text area. Possible values: "regular", "bold", "italic", "bold italic"                                                                                             |
-| margin        | `Spacing` |       0       | The text spacing from edges of remaining area                                                                                                                                               |
-| justification | `String`  |    "left"     | The text justification. Possible values: "left", "right", "center", "space-between"                                                                                                         |
-| line_spacing  | `u8`      |       0       | The gap between wrapped text lines                                                                                                                                                          |
+| Key           | Short description                                                                                                                                                                           | Type      | Default value |
+| :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------- | :-----------: |
+| wrap          | Sets possibility to line breaking when text overflows a line                                                                                                                                | `bool`    |     true      |
+| ellipsize_at  | Ellipsizes a text if it's totally overflows an area. Possible values: "end" and "middle". "end" - put ellipsis at end of word, "middle" - cut word at some middle of word and puts ellipsis | `String`  |     "end"     |
+| style         | Sets the style for whole text area. Possible values: "regular", "bold", "italic", "bold italic"                                                                                             | `String`  |   "regular"   |
+| margin        | The text spacing from edges of remaining area                                                                                                                                               | `Spacing` |       0       |
+| justification | The text justification. Possible values: "left", "right", "center", "space-between"                                                                                                         | `String`  |    "left"     |
+| line_spacing  | The gap between wrapped text lines. Measures in px                                                                                                                                          | `u8`      |       0       |
 
 For more explanation how the text draws, please visit [the other documentation about text](BannerLayout.md#text).
 
@@ -327,10 +344,60 @@ since creation.
 
 The value `0` means will never expired.
 
+---
+
+## Themes
+
+This is feature of the `Noti` application. Instead of defining the color values among
+config properties in main config file you can define array of tables named `theme`. You should
+put name of theme, otherwise it will be skipped. And use the name of theme in `display.theme`.
+
+> [!NOTE]
+> Theme names should have **exact** match. Instead application will use the default theme.
+
+The `Theme` table:
+
+| Key      | Type     | Default value | Short description                        |
+| :------- | :------- | :-----------: | :--------------------------------------- |
+| low      | `Colors` |       -       | The colors for 'low' urgency banner      |
+| normal   | `Colors` |       -       | The colors for 'normal' urgency banner   |
+| critical | `Colors` |       -       | The colors for 'critical' urgency banner |
+
+### Colors
+
+Currently possible only three things that can be modified by colors: `foreground`, `background` and
+`border`.
+
+The `Colors` table:
+
+| Key        | Type    |               Default value               | Short description                        |
+| :--------- | :------ | :---------------------------------------: | :--------------------------------------- |
+| background | `Color` |                 "#FFFFFF"                 | The background color of banner           |
+| foreground | `Color` | "#000000" (but for `critical`: "#FF0000") | The foreground color which used for text |
+| border     | `Color` | "#000000" (but for `critical`: "#FF0000") | The border stroke color                  |
+
+**Example of theme usage**:
+
+```toml
+[display]
+theme = "my-theme"
+
+[[theme]]
+name = "my-theme"
+
+[theme.normal]
+border = "#0F0" # green border for normal urgency
+
+[theme.critical]
+border = "#F0F" # pink border for critical urgency
+```
+
+---;
+
 ## Apps
 
-This application have the huge feature named "app-config" in which you can redefine `display`
-table specifically for particular application.
+The `Noti` application have the huge feature named "app-config" in which you can redefine
+`display` table specifically for particular application.
 
 So need to introduce the rule of picking properties:
 
@@ -356,3 +423,10 @@ image = { max_size = 86 }
 
 # and so on..
 ```
+
+The `App` table:
+
+| Key     | Short description                                    | Type                  |
+| :------ | :--------------------------------------------------- | :-------------------- |
+| name    | The name of application                              | `String`              |
+| display | The display configuration table for this application | [`Display`](#display) |

--- a/docs/ConfigProperties.md
+++ b/docs/ConfigProperties.md
@@ -83,15 +83,15 @@ to go to through from the first one to the last one.
 
 The 'general' word means that it applies to application or all banners together. Here a table of possible general properties and below we'll go through all properties.
 
-| Property name       | Description                                         | Type                  | Default value |
-| :------------------ | :-------------------------------------------------- | :-------------------- | :-----------: |
-| [font](#font)       | [See desc](#font)                                   | `String`              |  "Noto Sans"  |
-| [width](#width)     | The width of banner frame.                          | `u16`                 |      300      |
-| [height](#height)   | The height of banner frame.                         | `u16`                 |      150      |
-| [anchor](#anchor)   | [See desc](#anchor)                                 | `String`              |  "top right"  |
-| [gap](#gap)         | The space size between two banners. Measures in px. | `u8`                  |      10       |
-| [offset](#offset)   | [See desc](#offset)                                 | `[u8, u8]`            |    [0, 0]     |
-| [sorting](#sorting) | [See desc](#sorting)                                | `String` or `Sorting` |   "default"   |
+| Property name | Description                                         | Type                  | Default value |
+| :------------ | :-------------------------------------------------- | :-------------------- | :-----------: |
+| `font`        | [See desc](#font)                                   | `String`              |  "Noto Sans"  |
+| `width`       | The width of banner frame.                          | `u16`                 |      300      |
+| `height`      | The height of banner frame.                         | `u16`                 |      150      |
+| `anchor`      | [See desc](#anchor)                                 | `String`              |  "top right"  |
+| `gap`         | The space size between two banners. Measures in px. | `u8`                  |      10       |
+| `offset`      | [See desc](#offset)                                 | `[u8, u8]`            |    [0, 0]     |
+| `sorting`     | [See desc](#sorting)                                | `String` or `Sorting` |   "default"   |
 
 ### Font
 
@@ -264,12 +264,10 @@ margin = 5
 ### Image
 
 Usually the notification can contain the image or icon and it draws at the right of
-banner. More about it in [banner layout](BannerLayout.md#image)
+banner. More about it in [banner layout](BannerLayout.md#image). Our application can
+perform some actions which in result the image will look very pleasant for most users.
 
-Our application can perform some actions which in result the image will look very
-pleasant for most users.
-
-Here a table of `Image` properties:
+Here's a table of `Image` properties:
 
 | Property name   | Description                                                                                                                                            | Type                                                                    | Default value |
 | :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- | :-----------: |


### PR DESCRIPTION
# Motivation

At begin of development of the application there was not complex configuration, just simple and single TOML file. But since we feeding this application by coolest features, the config file becomes very complex.

To simplify this process, need to separate single config file into smaller. And I begin from colors.

## Breaking changes

I decided that we shouldn't save backward compatibility in this case because we aim to simplicity. So previous config values will be deprecated and removed from parsing.

Also there is other breaking change - I've moved the `font_size` property (previously unnamed) from `general.font` into `TextProperty`. It is more convenient and logic to use font size per text field instead of using global font size.

## TODO

- [X] - group colors into `Theme` structure
- [X] - move `font_size` into `TextProperty`
- [x] - implement `import` of config files in TOML's root table
- [x] - update documentation