### PR TITLE
feat: reload font by updating config and use `Rc` instead of `Arc`s

### DIFF
--- a/crates/backend/src/render.rs
+++ b/crates/backend/src/render.rs
@@ -1,8 +1,6 @@
 use std::time::Duration;
 
-use super::internal_messages::{
-    InternalChannel, RendererInternalChannel, ServerInternalChannel, ServerMessage,
-};
+use super::internal_messages::{RendererInternalChannel, ServerMessage};
 use config::Config;
 use log::{debug, info};
 use shared::file_watcher::FileState;
@@ -16,17 +14,15 @@ pub(crate) struct Renderer {
 }
 
 impl Renderer {
-    pub(crate) fn init(config: Config) -> anyhow::Result<(ServerInternalChannel, Self)> {
-        let (server_internal_channel, renderer_internal_channel) = InternalChannel::new().split();
-
-        Ok((
-            server_internal_channel,
-            Self {
-                window_manager: WindowManager::init(&config)?,
-                channel: renderer_internal_channel,
-                config,
-            },
-        ))
+    pub(crate) fn init(
+        config: Config,
+        renderer_internal_channel: RendererInternalChannel,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            window_manager: WindowManager::init(&config)?,
+            channel: renderer_internal_channel,
+            config,
+        })
     }
 
     pub(crate) fn run(&mut self) -> anyhow::Result<()> {
@@ -86,7 +82,6 @@ impl Renderer {
                     FileState::NotFound | FileState::NothingChanged => (),
                 };
 
-                // if self.config.update_themes() || self.window_manager.update_cache() {
                 if self.window_manager.update_cache() {
                     self.window_manager.update_by_config(&self.config)?;
                 }

--- a/crates/render/src/font.rs
+++ b/crates/render/src/font.rs
@@ -21,6 +21,7 @@ use super::{
 };
 
 pub struct FontCollection {
+    font_name: String,
     map: HashMap<FontStyle, Font>,
     pub emoji: Option<OwnedFace>,
 }
@@ -28,6 +29,15 @@ pub struct FontCollection {
 impl FontCollection {
     const ELLIPSIS: char = '…';
     const ACCEPTED_STYLES: [&'static str; 3] = ["Regular", "Bold", "Italic"];
+
+    pub fn update_by_font_name(&mut self, font_name: &str) -> anyhow::Result<()> {
+        if self.font_name == font_name {
+            return Ok(());
+        }
+
+        *self = Self::load_by_font_name(font_name)?;
+        Ok(())
+    }
 
     pub fn load_by_font_name(font_name: &str) -> anyhow::Result<Self> {
         debug!("Font: Trying load font by name {font_name}");
@@ -83,7 +93,11 @@ impl FontCollection {
             warn!("Font: Not found the 'NotoColorEmoj' font, emoji will be not displayed");
         }
 
-        Ok(Self { map, emoji })
+        Ok(Self {
+            font_name: font_name.to_owned(),
+            map,
+            emoji,
+        })
     }
 
     pub fn load_glyph_by_style(&self, font_style: &FontStyle, ch: char, px_size: f32) -> Glyph {


### PR DESCRIPTION
# Motivation

The font doesn't reloads when the config file updates because of expensiveness. I mean that some font files are large like nerd-fonts. So I decided do it more later. Now I think the application is ready to reload fonts.

## Main changes

I figured out that there is not need to use `Arc<T>` because it is enough to throw the `Renderer` initialization into child thread and initialize the `InternalChannel` separately. So, now in the renderer module uses `Rc<RefCell<T>>` which is faster than atomic analogues.

With it I've added the font reload after checking the font name. If the font names are same, font won't reload.