### PR TITLE
fix: correct timeout value parsing

### DIFF
--- a/crates/config/src/display.rs
+++ b/crates/config/src/display.rs
@@ -286,6 +286,20 @@ critical = 0 # but for critical the default value will be overriden
         Ok(v.into())
     }
 
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error, {
+        if v < 0 {
+            Err(serde::de::Error::invalid_type(
+                serde::de::Unexpected::Signed(v),
+                &self,
+            ))
+        } else {
+            Ok((v.clamp(0, u16::MAX as i64) as u16).into())
+        }
+        
+    }
+
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
     where
         A: serde::de::MapAccess<'de>,

--- a/crates/config/src/display.rs
+++ b/crates/config/src/display.rs
@@ -287,8 +287,9 @@ critical = 0 # but for critical the default value will be overriden
     }
 
     fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error, {
+    where
+        E: serde::de::Error,
+    {
         if v < 0 {
             Err(serde::de::Error::invalid_type(
                 serde::de::Unexpected::Signed(v),
@@ -297,7 +298,6 @@ critical = 0 # but for critical the default value will be overriden
         } else {
             Ok((v.clamp(0, u16::MAX as i64) as u16).into())
         }
-        
     }
 
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>


### PR DESCRIPTION
### Motivation

I found that the timeout value parses incorrectly from `display.timeout` as `u16` because of `serde`s specific internal work.

#### Changes

Added new method for `TimeoutVisitor` that accepts the `i64` value and converts into correct timeout value after clamping.