### PR TITLE
fix: make idle_threshold watchable and not block loop when idled

### DIFF
--- a/crates/backend/src/idle_notifier.rs
+++ b/crates/backend/src/idle_notifier.rs
@@ -6,7 +6,7 @@ use wayland_client::{
         wl_registry,
         wl_seat::{self, WlSeat},
     },
-    Dispatch,
+    Dispatch, QueueHandle,
 };
 use wayland_protocols::ext::idle_notify::v1::client::{
     ext_idle_notification_v1::{self, ExtIdleNotificationV1},
@@ -14,9 +14,13 @@ use wayland_protocols::ext::idle_notify::v1::client::{
 };
 
 pub struct IdleNotifier {
-    seat: Option<WlSeat>,
+    wl_seat: Option<WlSeat>,
+    notifier: Option<ExtIdleNotifierV1>,
+    notification: Option<ExtIdleNotificationV1>,
+
     threshold: u32,
-    idle_state: Option<IdleState>,
+    pub idle_state: Option<IdleState>,
+    pub was_idled: bool,
 }
 
 pub enum IdleState {
@@ -28,16 +32,32 @@ impl IdleNotifier {
     pub(crate) fn init(config: &Config) -> anyhow::Result<Self> {
         let threshold = config.general().idle_threshold.duration;
         let idle_notifier = Self {
-            seat: None,
+            wl_seat: None,
+            notifier: None,
+            notification: None,
+
             idle_state: None,
             threshold,
+            was_idled: false,
         };
         debug!("Idle Notifier: Initialized");
         Ok(idle_notifier)
     }
 
-    pub(crate) fn get_idle_state(&self) -> Option<&IdleState> {
-        self.idle_state.as_ref()
+    pub(super) fn recreate(&mut self, qh: &QueueHandle<Self>, config: &Config) {
+        if let Some(notifier) = self.notifier.as_ref() {
+            if let Some(notification) = self.notification.replace(notifier.get_idle_notification(
+                config.general().idle_threshold.duration,
+                self.wl_seat.as_ref().unwrap(),
+                qh,
+                (),
+            )) {
+                self.idle_state = None;
+                self.was_idled = false;
+                notification.destroy();
+                debug!("Idle Notifier: Was recreated by new idle_threshold value");
+            }
+        }
     }
 }
 
@@ -58,7 +78,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for IdleNotifier {
         {
             match interface.as_ref() {
                 "wl_seat" => {
-                    state.seat =
+                    state.wl_seat =
                         Some(registry.bind::<wl_seat::WlSeat, _, _>(name, version, qhandle, ()));
                     debug!("Idle Notifier: Bound the wl_seat");
                 }
@@ -71,9 +91,17 @@ impl Dispatch<wl_registry::WlRegistry, ()> for IdleNotifier {
                         registry.bind::<ExtIdleNotifierV1, _, _>(name, version, qhandle, ());
                     debug!("Idle Notifier: Bound the ext_idle_notifier_v1");
 
-                    if let Some(seat) = state.seat.as_ref() {
-                        idle_notifier.get_idle_notification(state.threshold, seat, qhandle, ());
+                    if let Some(seat) = state.wl_seat.as_ref() {
+                        state
+                            .notification
+                            .replace(idle_notifier.get_idle_notification(
+                                state.threshold,
+                                seat,
+                                qhandle,
+                                (),
+                            ));
                     }
+                    state.notifier.replace(idle_notifier);
                 }
                 _ => (),
             }
@@ -93,6 +121,7 @@ impl Dispatch<ExtIdleNotificationV1, ()> for IdleNotifier {
         match event {
             ext_idle_notification_v1::Event::Idled => {
                 state.idle_state = Some(IdleState::Idled);
+                state.was_idled = true;
                 debug!("Idle Notifier: Idled");
             }
             ext_idle_notification_v1::Event::Resumed => {

--- a/crates/backend/src/window.rs
+++ b/crates/backend/src/window.rs
@@ -27,7 +27,7 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
     zwlr_layer_surface_v1::{self, Anchor},
 };
 
-use super::internal_messages::RendererMessage;
+use super::internal_messages::BackendMessage;
 use config::{self, Config};
 use dbus::notification::{self, Notification};
 
@@ -302,7 +302,7 @@ impl Window {
             .for_each(BannerRect::reset_timeout);
     }
 
-    pub(super) fn handle_click(&mut self, config: &Config) -> Vec<RendererMessage> {
+    pub(super) fn handle_click(&mut self, config: &Config) -> Vec<BackendMessage> {
         if let PrioritiedPressState::Unpressed = self.pointer_state.press_state {
             return vec![];
         }
@@ -319,7 +319,7 @@ impl Window {
             return self
                 .remove_banners_by_id(&[id])
                 .into_iter()
-                .map(|notification| RendererMessage::ClosedNotification {
+                .map(|notification| BackendMessage::ClosedNotification {
                     id: notification.id,
                     reason: dbus::actions::ClosingReason::DismissedByUser,
                 })

--- a/crates/backend/src/window_manager.rs
+++ b/crates/backend/src/window_manager.rs
@@ -7,7 +7,7 @@ use wayland_client::{Connection, EventQueue, QueueHandle};
 use crate::cache::CachedLayout;
 use crate::dispatcher::Dispatcher;
 
-use super::internal_messages::RendererMessage;
+use super::internal_messages::BackendMessage;
 use config::Config;
 use dbus::notification::Notification;
 
@@ -23,7 +23,7 @@ pub(crate) struct WindowManager {
     font_collection: Rc<RefCell<FontCollection>>,
     cached_layouts: CachedData<PathBuf, CachedLayout>,
 
-    events: Vec<RendererMessage>,
+    events: Vec<BackendMessage>,
 
     notification_queue: VecDeque<Notification>,
 }
@@ -166,7 +166,7 @@ impl WindowManager {
                 .into_iter()
                 .map(|notification| notification.id)
                 .for_each(|id| {
-                    self.events.push(RendererMessage::ClosedNotification {
+                    self.events.push(BackendMessage::ClosedNotification {
                         id,
                         reason: dbus::actions::ClosingReason::CallCloseNotification,
                     })
@@ -187,7 +187,7 @@ impl WindowManager {
             }
 
             notifications.into_iter().for_each(|notification| {
-                self.events.push(RendererMessage::ClosedNotification {
+                self.events.push(BackendMessage::ClosedNotification {
                     id: notification.id,
                     reason: dbus::actions::ClosingReason::Expired,
                 })
@@ -199,7 +199,7 @@ impl WindowManager {
         Ok(())
     }
 
-    pub(crate) fn pop_event(&mut self) -> Option<RendererMessage> {
+    pub(crate) fn pop_event(&mut self) -> Option<BackendMessage> {
         self.events.pop()
     }
 


### PR DESCRIPTION
### Motivation

Closes #79

#### Changes

With it also renamed important structs like `Renderer` -> `BackendManager` and it was made for better understanding of backend crate.