### PR TITLE
fix: introduce paragraphs to handle line breaks in text

### DIFF
--- a/crates/render/src/text.rs
+++ b/crates/render/src/text.rs
@@ -338,10 +338,6 @@ impl LineRect {
         ellipsis: Glyph,
         ellipsize_at: &EllipsizeAt,
     ) -> EllipsizationState {
-        if paragraph_num != self.paragraph_num {
-            last_word.replace(WordRect::new_empty());
-        }
-
         match ellipsize_at {
             EllipsizeAt::Middle => {
                 self.ellipsize_middle(last_word, ellipsis);
@@ -349,6 +345,9 @@ impl LineRect {
             }
             EllipsizeAt::End => {
                 if last_word.is_some() || self.available_space < 0 {
+                    if paragraph_num != self.paragraph_num {
+                        last_word.replace(WordRect::new_empty());
+                    }
                     self.ellipsize_end(ellipsis)
                 } else {
                     EllipsizationState::Complete


### PR DESCRIPTION
### Motivation

When a text was sent with line breaks due some reasons. Usually it made for structuring. But the application doesn't handle this case, so it ended up not beautiful result. Text which should be separated into paragraphs looks like single massive paragraph.

#### Changes

Now the text with line breaks separates into paragraphs correctly. The ellipsization rule works as previously, but here adds a new rule - "If line from next paragraph cannot be ellipsized, then don't include the words from next paragraph to current and put ellipsis to the last line with word removal if needed".