### PR TITLE
feat: add --print-id flag to print notification id into stdout

### DIFF
--- a/crates/app/cli.rs
+++ b/crates/app/cli.rs
@@ -73,6 +73,14 @@ pub struct SendCommand {
     timeout: i32,
 
     #[arg(
+        short,
+        long,
+        help = "Prints ID",
+        long_help = "Prints the ID of created notification",
+    )]
+    print_id: bool,
+
+    #[arg(
         short = 'A',
         long,
         help = "Actions",
@@ -209,7 +217,7 @@ async fn send(noti: client::NotiClient<'_>, args: SendCommand) -> anyhow::Result
         schedule: args.schedule,
     };
 
-    noti.send_notification(
+    let notification_id = noti.send_notification(
         args.replaces_id,
         args.app_name,
         args.icon,
@@ -220,7 +228,13 @@ async fn send(noti: client::NotiClient<'_>, args: SendCommand) -> anyhow::Result
         args.hints,
         hints_data,
     )
-    .await
+    .await?;
+
+    if args.print_id {
+        print!("{notification_id}")
+    }
+
+    Ok(())
 }
 
 async fn server_info(noti: client::NotiClient<'_>) -> anyhow::Result<()> {

--- a/crates/app/cli.rs
+++ b/crates/app/cli.rs
@@ -76,7 +76,7 @@ pub struct SendCommand {
         short,
         long,
         help = "Prints ID",
-        long_help = "Prints the ID of created notification",
+        long_help = "Prints the ID of created notification"
     )]
     print_id: bool,
 
@@ -217,18 +217,19 @@ async fn send(noti: client::NotiClient<'_>, args: SendCommand) -> anyhow::Result
         schedule: args.schedule,
     };
 
-    let notification_id = noti.send_notification(
-        args.replaces_id,
-        args.app_name,
-        args.icon,
-        args.summary,
-        args.body,
-        args.timeout,
-        args.actions,
-        args.hints,
-        hints_data,
-    )
-    .await?;
+    let notification_id = noti
+        .send_notification(
+            args.replaces_id,
+            args.app_name,
+            args.icon,
+            args.summary,
+            args.body,
+            args.timeout,
+            args.actions,
+            args.hints,
+            hints_data,
+        )
+        .await?;
 
     if args.print_id {
         print!("{notification_id}")

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -41,7 +41,7 @@ impl<'a> NotiClient<'a> {
         actions: Vec<String>,
         hints: Vec<String>,
         hints_data: HintsData,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<u32> {
         debug!("Client: Building hints and actions from user prompt");
         let new_hints = build_hints(&hints, hints_data)?;
 
@@ -59,7 +59,7 @@ impl<'a> NotiClient<'a> {
             \ttimeout - {timeout}"
         );
 
-        self.dbus_client
+        let notification_id = self.dbus_client
             .notify(
                 &app_name, id, &icon, &summary, &body, actions, new_hints, timeout,
             )
@@ -67,7 +67,7 @@ impl<'a> NotiClient<'a> {
 
         debug!("Client: Successful send");
 
-        Ok(())
+        Ok(notification_id)
     }
 
     pub async fn get_server_info(&self) -> anyhow::Result<()> {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -59,7 +59,8 @@ impl<'a> NotiClient<'a> {
             \ttimeout - {timeout}"
         );
 
-        let notification_id = self.dbus_client
+        let notification_id = self
+            .dbus_client
             .notify(
                 &app_name, id, &icon, &summary, &body, actions, new_hints, timeout,
             )


### PR DESCRIPTION
### Motivation

One more reason to use our client application. Closes #76 

#### Changes

Added a way to print returned notification id into stdout. Flags: `-p` and `--print-id`.