### PR TITLE
fix: replace notifications bypass general.limit

### DIFF
--- a/crates/backend/src/window.rs
+++ b/crates/backend/src/window.rs
@@ -4,6 +4,7 @@ use shared::cached_data::CachedData;
 use std::{
     cell::RefCell,
     cmp::Ordering,
+    collections::VecDeque,
     fs::File,
     os::{
         fd::{AsFd, BorrowedFd},
@@ -192,12 +193,10 @@ impl Window {
 
     pub(super) fn update_banners(
         &mut self,
-        mut notifications: Vec<Notification>,
+        notifications: Vec<Notification>,
         config: &Config,
         cached_layouts: &CachedData<PathBuf, CachedLayout>,
     ) {
-        self.replace_by_indices(&mut notifications, config, cached_layouts);
-
         self.banners
             .extend(notifications.into_iter().map(|notification| {
                 let mut banner_rect = BannerRect::init(notification);
@@ -214,7 +213,7 @@ impl Window {
 
     pub(super) fn replace_by_indices(
         &mut self,
-        notifications: &mut Vec<Notification>,
+        notifications: &mut VecDeque<Notification>,
         config: &Config,
         cached_layouts: &CachedData<PathBuf, CachedLayout>,
     ) {
@@ -225,7 +224,7 @@ impl Window {
             .collect();
 
         for notification_index in matching_indices.into_iter().rev() {
-            let notification = notifications.remove(notification_index);
+            let notification = notifications.remove(notification_index).unwrap();
 
             let rect = &mut self.banners[&notification.id];
             rect.update_data(notification);

--- a/crates/backend/src/window_manager.rs
+++ b/crates/backend/src/window_manager.rs
@@ -119,6 +119,8 @@ impl WindowManager {
                 return self.display_all_notifications(config);
             }
 
+            window.replace_by_indices(&mut self.notification_queue, config, &self.cached_layouts);
+
             let current_notifications_count = window.get_current_notifications_count();
             let available_slots = notifications_limit.saturating_sub(current_notifications_count);
 
@@ -138,6 +140,8 @@ impl WindowManager {
 
     fn display_all_notifications(&mut self, config: &Config) -> anyhow::Result<()> {
         if let Some(window) = self.window.as_mut() {
+            window.replace_by_indices(&mut self.notification_queue, config, &self.cached_layouts);
+
             let notifications_to_display: Vec<Notification> =
                 self.notification_queue.drain(..).collect();
 


### PR DESCRIPTION
### Motivation

Notification which should be replaced by id doesn't replaces because it stores in notification queue. And a lot of time will pass before the replacement will show.

#### Solution

Replace the notifications by-pass `general.limit` option using direct call `replace_by_indices` methods.