### PR TITLE
refactor: clean Cargo.toml's files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,6 @@ dependencies = [
  "dbus",
  "glob",
  "humantime",
- "inotify 0.10.2",
  "log",
  "macros",
  "serde",
@@ -1281,19 +1280,6 @@ checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "inotify"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
-dependencies = [
- "bitflags 1.3.2",
- "futures-core",
- "inotify-sys",
- "libc",
- "tokio",
 ]
 
 [[package]]
@@ -2311,7 +2297,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derive_more",
- "inotify 0.11.0",
+ "inotify",
  "log",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,16 +31,20 @@ tokio = { version = "1.38.0", features = ["full"] }
 log = "0.4.22"
 zbus = "4.4.0"
 derive_more = { version = "1.0.0", features = ["display"] }
-config = { path = "crates/config" }
-render = { path = "crates/render" }
-dbus = { path = "crates/dbus" }
-shared = { path = "crates/shared" }
+humantime = "2.1.0"
+
+config.path = "crates/config"
+render.path = "crates/render"
+dbus.path = "crates/dbus"
+shared.path = "crates/shared"
+macros.path = "crates/macros"
 
 [dependencies]
-anyhow = { workspace = true }
-tokio = { workspace = true }
-backend = { path = "crates/backend" }
-client = { path = "crates/client" }
-config = { workspace = true }
+config.workspace = true
+backend.path = "crates/backend"
+client.path = "crates/client"
+
+anyhow.workspace = true
+tokio.workspace = true
 clap = { version = "4.5.7", features = ["derive"] }
 env_logger = "0.11.5"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -5,19 +5,20 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
-tokio = { workspace = true }
-log = { workspace = true }
-dbus = { workspace = true }
-config = { workspace = true }
-render = { workspace = true }
-shared = { workspace = true }
-filetype = { path = "../filetype" }
+dbus.workspace = true
+config.workspace = true
+render.workspace = true
+shared.workspace = true
+filetype.path = "../filetype"
+
+anyhow.workspace = true
+tokio.workspace = true
+log.workspace = true
+humantime.workspace = true
 
 tempfile = "3.12.0"
 wayland-client = "0.31.5"
 wayland-protocols = { version = "0.32.3", features = ["client", "wayland-client", "staging", "unstable"] }
 wayland-protocols-wlr = { version = "0.3.3", features = ["client", "wayland-client"] }
 indexmap = "2.4.0"
-humantime = "2.1.0"
 chrono = "0.4.39"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -5,8 +5,9 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
-tokio = { workspace = true }
-log = { workspace = true }
-dbus = { workspace = true }
-zbus = { workspace = true }
+dbus.workspace = true
+
+anyhow.workspace = true
+tokio.workspace = true
+log.workspace = true
+zbus.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -5,15 +5,15 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-macros = { path = "../macros" }
-dbus = { workspace = true }
-anyhow = { workspace = true }
-log = { workspace = true }
-shared = { workspace = true }
+dbus.workspace = true
+macros.workspace = true
+shared.workspace = true
 
-inotify = "0.10.2"
+anyhow.workspace = true
+log.workspace = true
+humantime.workspace = true
+
 serde = "1.0.205"
 toml = "0.8.19"
 shellexpand = "3.1.0"
-humantime = "2.1.0"
 glob = "0.3.1"

--- a/crates/dbus/Cargo.toml
+++ b/crates/dbus/Cargo.toml
@@ -5,11 +5,11 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
-tokio = { workspace = true }
-log = { workspace = true }
-zbus = { workspace = true }
+anyhow.workspace = true
+tokio.workspace = true
+log.workspace = true
+zbus.workspace = true
+derive_more.workspace = true
 
-derive_more = { version = "1.0.0", features = ["display"] }
 html-escape = "0.2.13"
 unic-segment = "0.9.0"

--- a/crates/filetype/Cargo.toml
+++ b/crates/filetype/Cargo.toml
@@ -5,11 +5,12 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-shared = { workspace = true }
-render = { workspace = true }
-config = { workspace = true }
-anyhow = { workspace = true }
-log = { workspace = true }
+shared.workspace = true
+render.workspace = true
+config.workspace = true
+
+anyhow.workspace = true
+log.workspace = true
 
 pest = { version = "2.7.14", features = ["miette-error", "pretty-print"] }
 pest_derive = { version = "2.7.14", features = ["grammar-extras"] }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -13,4 +13,4 @@ quote = "1.0.36"
 syn = "2.0.72"
 
 [dev-dependencies]
-shared = { workspace = true }
+shared.workspace = true

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -5,13 +5,14 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-log = { workspace = true }
-config = { workspace = true }
-anyhow = { workspace = true }
-dbus = { workspace = true }
-shared = { workspace = true }
-macros = { path = "../macros" }
-derive_more = { workspace = true }
+config.workspace = true
+dbus.workspace = true
+shared.workspace = true
+macros.workspace = true
+
+log.workspace = true
+anyhow.workspace = true
+derive_more.workspace = true
 
 derive_builder = "0.20.0"
 ab_glyph = "0.2.28"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -5,8 +5,8 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-log = { workspace = true }
-anyhow = { workspace = true }
-derive_more = { workspace = true }
+log.workspace = true
+anyhow.workspace = true
+derive_more.workspace = true
 
 inotify = "0.11.0"


### PR DESCRIPTION
### Motivation

The syntax `package = { workspase = true }` looks longer and dirtier than `package.workspace = true`, so I wanted to clean curly braces with short syntax.

#### Changes

Reorganized packages. Now for every crate the packages was split in three groups:
- workspace members as dependencies;
- foreign crates as workspace dependencies;
- local dependencies.

With it, as I mentioned in [motivation](#motivation), the syntax became shorter and more cleaner than previously. Also the syntax `package = { path = "..." }` was reduced to `package.path = "..."`.