### PR TITLE
feat: add aliases for custom layout of notification banner

### DIFF
--- a/crates/config/src/display.rs
+++ b/crates/config/src/display.rs
@@ -111,7 +111,7 @@ public! {
 public! {
     #[derive(ConfigProperty, GenericBuilder, Debug, Clone)]
     #[cfg_prop(name(TomlImageProperty), derive(Debug, Clone, Default, Deserialize))]
-    #[gbuilder(name(GBuilderImageProperty))]
+    #[gbuilder(name(GBuilderImageProperty), derive(Clone))]
     struct ImageProperty {
         #[cfg_prop(default(64))]
         #[gbuilder(default(64))]
@@ -171,7 +171,7 @@ impl TryFromValue for ResizingMethod {
 public! {
     #[derive(ConfigProperty, GenericBuilder, Debug, Default, Clone)]
     #[cfg_prop(name(TomlBorder), derive(Debug, Clone, Default, Deserialize))]
-    #[gbuilder(name(GBuilderBorder))]
+    #[gbuilder(name(GBuilderBorder), derive(Clone))]
     struct Border {
         #[cfg_prop(default(0))]
         #[gbuilder(default(0))]

--- a/crates/config/src/spacing.rs
+++ b/crates/config/src/spacing.rs
@@ -9,7 +9,7 @@ use serde::{de::Visitor, Deserialize};
 use shared::value::TryFromValue;
 
 #[derive(GenericBuilder, Debug, Default, Clone)]
-#[gbuilder(name(GBuilderSpacing))]
+#[gbuilder(name(GBuilderSpacing), derive(Clone))]
 pub struct Spacing {
     #[gbuilder(default(0))]
     top: u8,

--- a/crates/config/src/text.rs
+++ b/crates/config/src/text.rs
@@ -6,8 +6,8 @@ use super::{public, Spacing};
 
 public! {
     #[derive(ConfigProperty, GenericBuilder, Debug, Clone)]
-    #[cfg_prop(name(TomlTextProperty),derive(Debug, Clone, Default, Deserialize))]
-    #[gbuilder(name(GBuilderTextProperty))]
+    #[cfg_prop(name(TomlTextProperty), derive(Debug, Clone, Default, Deserialize))]
+    #[gbuilder(name(GBuilderTextProperty), derive(Clone))]
     struct TextProperty {
         #[cfg_prop(default(true))]
         #[gbuilder(default(true))]

--- a/crates/filetype/src/layout.pest
+++ b/crates/filetype/src/layout.pest
@@ -11,6 +11,8 @@
 // They will be here until the Pest parser gets better token
 // analyzing.
 
+Alias = { "alias" }
+
 OpeningBrace = { "{" }
 ClosingBrace = { "}" }
 
@@ -24,7 +26,10 @@ Hashtag = { "#" }
 
 // END BASE TOKENS
 
-Layout = { SOI ~ NodeType ~ EOI }
+Layout = { SOI ~ AliasDefinitions? ~ NodeType ~ EOI }
+
+AliasDefinitions = { AliasDefinition+ }
+AliasDefinition = { Alias ~ Identifier ~ Equal ~ TypeValue }
 
 NodeType = { 
   Identifier ~ OpeningParenthesis

--- a/crates/filetype/src/lib.rs
+++ b/crates/filetype/src/lib.rs
@@ -22,21 +22,25 @@ fn minimal_type() {
 
         // WText(kind = title)
         
-        FlexContainer(
+        alias SizedText = Text(font_size = 20)
+        alias DefaultAlignment = Alignment(
+            horizontal = start,
+            vertical = space_between,
+        )
+
+        alias Title = SizedText(kind = title)
+        alias Row = FlexContainer(direction = horizontal)
+        
+        Row(
             max_width = 400,
             max_height = 120,
 
-            direction = horizontal,
-            alignment = Alignment(
-                horizontal = start,
-                vertical = space_between,
-            )
+            alignment = DefaultAlignment(),
         ) {
             Image(
                 max_size = 86,
             )
-            Text(
-                kind = title,
+            Title(
                 wrap = false,
                 line_spacing = 10,
             )

--- a/crates/filetype/src/parser.rs
+++ b/crates/filetype/src/parser.rs
@@ -91,3 +91,83 @@ fn test_redundant_semicolon_in_children() {
     )
     .unwrap();
 }
+
+#[test]
+#[should_panic]
+fn test_invalid_alias_definition() {
+    LayoutParser::parse(
+        Rule::Layout,
+        r#"
+            alas Test = Title()
+
+            FlexContainer(
+                min_width = 3,
+                max_width = 4
+            ) {
+                Text()
+                Image()
+            }
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_alias_definition2() {
+    LayoutParser::parse(
+        Rule::Layout,
+        r#"
+            alias Test = 3
+
+            FlexContainer(
+                min_width = 3,
+                max_width = 4
+            ) {
+                Text()
+                Image()
+            }
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_alias_definition3() {
+    LayoutParser::parse(
+        Rule::Layout,
+        r#"
+            alias Test = literal
+
+            FlexContainer(
+                min_width = 3,
+                max_width = 4
+            ) {
+                Text()
+                Image()
+            }
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_alias_definition4() {
+    LayoutParser::parse(
+        Rule::Layout,
+        r#"
+            alias _ = Text()
+
+            FlexContainer(
+                min_width = 3,
+                max_width = 4
+            ) {
+                Text()
+                Image()
+            }
+        "#,
+    )
+    .unwrap();
+}

--- a/crates/macros/src/general.rs
+++ b/crates/macros/src/general.rs
@@ -160,9 +160,12 @@ pub struct DeriveInfo {
 }
 
 impl DeriveInfo {
-    pub fn from_ident_and_input(ident: syn::Ident, input: &syn::parse::ParseStream) -> syn::Result<Self> {
+    pub fn from_ident_and_input(
+        ident: syn::Ident,
+        input: &syn::parse::ParseStream,
+    ) -> syn::Result<Self> {
         let content;
-        Ok(Self{
+        Ok(Self {
             ident,
             paren: syn::parenthesized!(content in input),
             traits: content.parse_terminated(syn::Ident::parse_any, Token![,])?,

--- a/crates/macros/src/general.rs
+++ b/crates/macros/src/general.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use quote::ToTokens;
 use syn::{ext::IdentExt, parse::Parse, spanned::Spanned, Ident, Token};
 
 #[derive(Clone)]
@@ -149,6 +150,34 @@ impl Parse for DefaultAssignment {
         } else {
             DefaultAssignment::Expression(input.parse()?)
         })
+    }
+}
+
+pub struct DeriveInfo {
+    ident: syn::Ident,
+    paren: syn::token::Paren,
+    traits: syn::punctuated::Punctuated<syn::Ident, Token![,]>,
+}
+
+impl DeriveInfo {
+    pub fn from_ident_and_input(ident: syn::Ident, input: &syn::parse::ParseStream) -> syn::Result<Self> {
+        let content;
+        Ok(Self{
+            ident,
+            paren: syn::parenthesized!(content in input),
+            traits: content.parse_terminated(syn::Ident::parse_any, Token![,])?,
+        })
+    }
+}
+
+impl ToTokens for DeriveInfo {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        proc_macro2::Punct::new('#', proc_macro2::Spacing::Joint).to_tokens(tokens);
+        syn::token::Bracket::default().surround(tokens, |tokens| {
+            self.ident.to_tokens(tokens);
+            self.paren
+                .surround(tokens, |tokens| self.traits.to_tokens(tokens));
+        });
     }
 }
 

--- a/crates/macros/src/generic_builder.rs
+++ b/crates/macros/src/generic_builder.rs
@@ -16,7 +16,7 @@ pub(super) fn make_derive(item: TokenStream) -> TokenStream {
     let generic_builder = structure.create_generic_builder(&attribute_info.struct_info);
 
     let mut tokens = proc_macro2::TokenStream::new();
-    generic_builder.build_gbuilder_struct(&mut tokens, &attribute_info.struct_info);
+    generic_builder.build_gbuilder_struct(&mut tokens, &attribute_info);
 
     propagate_err!(generic_builder.build_gbuilder_impl(&mut tokens, &attribute_info, &structure));
 
@@ -33,7 +33,7 @@ impl Structure {
     fn build_gbuilder_struct(
         &self,
         tokens: &mut proc_macro2::TokenStream,
-        struct_info: &StructInfo,
+        attribute_info: &AttributeInfo<StructInfo, FieldInfo>,
     ) {
         let Structure {
             ref visibility,
@@ -44,7 +44,8 @@ impl Structure {
             ..
         } = self;
 
-        let derive_info = struct_info
+        let derive_info = attribute_info
+            .struct_info
             .derive_info
             .as_ref()
             .map(ToTokens::to_token_stream)
@@ -59,7 +60,18 @@ impl Structure {
             let mut fields = fields.clone();
             fields.iter_mut().for_each(|field| {
                 field.attrs.clear();
-                field.ty = wrap_by_option(field.ty.clone())
+                field.ty = if let Some(use_gbuilder) = attribute_info
+                    .fields_info
+                    .get(&field_name(field))
+                    .and_then(|field_info| field_info.use_gbuilder.as_ref())
+                {
+                    syn::Type::Path(syn::TypePath {
+                        qself: None,
+                        path: use_gbuilder.clone(),
+                    })
+                } else {
+                    wrap_by_option(field.ty.clone())
+                }
             });
             fields.to_tokens(tokens)
         });
@@ -77,16 +89,14 @@ impl Structure {
             .filter(|field| !attribute_info.is_hidden_field(field))
             .collect::<Punctuated<&syn::Field, Token![,]>>();
 
-        let fn_new = self.build_fn_new();
-        let fn_contains_field = self.build_fn_contains_field(&unhidden_fields)?;
-        let fn_set_value = self.build_fn_set_value(&unhidden_fields);
+        let fn_new = self.build_fn_new(attribute_info);
+        let fn_set_value = self.build_fn_set_value(&unhidden_fields, attribute_info);
         let fn_try_build = self.build_fn_try_build(target_struct, attribute_info);
 
         let gbuilder_ident = &self.name;
         quote! {
             impl #gbuilder_ident {
                 #fn_new
-                #fn_contains_field
                 #fn_set_value
                 #fn_try_build
             }
@@ -102,12 +112,25 @@ impl Structure {
         Ok(())
     }
 
-    fn build_fn_new(&self) -> proc_macro2::TokenStream {
+    fn build_fn_new(
+        &self,
+        attribute_info: &AttributeInfo<StructInfo, FieldInfo>,
+    ) -> proc_macro2::TokenStream {
         let init_members: Punctuated<proc_macro2::TokenStream, Token![,]> = self
             .fields
             .iter()
             .map(|field| field.ident.clone().expect("Fields should be named"))
-            .map(|field_ident| quote! { #field_ident: None })
+            .map(|field_ident| {
+                if let Some(use_gbuilder) = attribute_info
+                    .fields_info
+                    .get(&field_ident.to_string())
+                    .and_then(|field_info| field_info.use_gbuilder.as_ref())
+                {
+                    quote! { #field_ident: #use_gbuilder::new() }
+                } else {
+                    quote! { #field_ident: None }
+                }
+            })
             .collect();
 
         let visibility = &self.visibility;
@@ -120,41 +143,20 @@ impl Structure {
         }
     }
 
-    fn build_fn_contains_field(
-        &self,
-        unhidden_fields: &Punctuated<&syn::Field, Token![,]>,
-    ) -> syn::Result<proc_macro2::TokenStream> {
-        let quoted_field_names: Punctuated<String, Token![,]> = unhidden_fields
-            .iter()
-            .map(|field| {
-                field
-                    .ident
-                    .clone()
-                    .expect("Fields should be named")
-                    .to_string()
-            })
-            .collect();
-        let field_count = quoted_field_names.len();
-
-        let visibility = &self.visibility;
-        Ok(quote! {
-            const FIELD_NAMES: [&'static str; #field_count] = [
-                #quoted_field_names
-            ];
-
-            #visibility fn contains_field(&self, field_name: &str) -> bool {
-                Self::FIELD_NAMES.contains(&field_name)
-            }
-        })
-    }
-
     fn build_fn_set_value(
         &self,
         unhidden_fields: &Punctuated<&syn::Field, Token![,]>,
+        attribute_info: &AttributeInfo<StructInfo, FieldInfo>,
     ) -> proc_macro2::TokenStream {
-        let set_members: Punctuated<proc_macro2::TokenStream, Token![,]> = unhidden_fields
-            .clone()
-            .into_iter()
+        let (simple_fields, associated_gbuilders): (Vec<&syn::Field>, Vec<&syn::Field>) =
+            unhidden_fields.clone().into_iter().partition(|field| {
+                attribute_info
+                    .fields_info
+                    .get(&field_name(field))
+                    .is_none_or(|field_info| field_info.use_gbuilder.is_none())
+            });
+
+        let set_members: Punctuated<proc_macro2::TokenStream, Token![,]> = simple_fields.into_iter()
             .map(|field| {
                 let field_ident = field.ident.clone().expect("Fields should be named");
                 let field_name = field_ident.to_string();
@@ -162,8 +164,23 @@ impl Structure {
             })
             .collect();
 
+        let associated_gbuilder_assignments: Vec<proc_macro2::TokenStream> = associated_gbuilders
+            .into_iter()
+            .map(|field| {
+                let field_ident = field.ident.as_ref().expect("Fields should be named");
+
+                quote! {
+                    match self.#field_ident.set_value(field_name, value) {
+                        Ok(_) => return Ok(self),
+                        Err(shared::error::ConversionError::UnknownField{ value: returned_value,.. }) => value = returned_value,
+                        Err(err) => return Err(err),
+                    }
+                }
+            })
+            .collect();
+
         let err_expression = quote! {
-            Err(shared::error::ConversionError::UnknownField { field_name: field_name.to_string() })
+            Err(shared::error::ConversionError::UnknownField { field_name: field_name.to_string(), value })
         };
         let function_body = if set_members.is_empty() {
             err_expression
@@ -171,7 +188,11 @@ impl Structure {
             quote! {
                 match field_name {
                     #set_members,
-                    _ => return #err_expression
+                    _ => {
+                        #(#associated_gbuilder_assignments)*
+
+                        return #err_expression
+                    }
                 }
                 Ok(self)
             }
@@ -182,7 +203,7 @@ impl Structure {
             #visibility fn set_value(
                 &mut self,
                 field_name: &str,
-                value: shared::value::Value
+                mut value: shared::value::Value
             ) -> std::result::Result<&mut Self, shared::error::ConversionError> {
                 #function_body
             }
@@ -205,6 +226,15 @@ impl Structure {
                 let field_name = field_ident.to_string();
                 let mut line = quote! { #field_ident: self.#field_ident };
 
+                let is_associated_gbuilder = attribute_info
+                    .fields_info
+                    .get(&field_name)
+                    .and_then(|field_info| field_info.use_gbuilder.as_ref())
+                    .is_some();
+                if is_associated_gbuilder {
+                    line = quote! { #line.try_build() }
+                };
+
                 if let Some(default_assignment) = attribute_info
                     .fields_info
                     .get(&field_name)
@@ -212,18 +242,20 @@ impl Structure {
                 {
                     match default_assignment {
                         DefaultAssignment::Expression(expr) => {
-                            quote! { .unwrap_or_else(|| #expr) }.to_tokens(&mut line)
+                            line = quote! { #line.unwrap_or_else(|| #expr) }
                         }
                         DefaultAssignment::FunctionCall(function_path) => {
-                            quote! { .unwrap_or_else(#function_path) }.to_tokens(&mut line)
+                            line = quote! { #line.unwrap_or_else(#function_path) }
                         }
                         DefaultAssignment::DefaultCall => {
-                            quote! { .unwrap_or_default() }.to_tokens(&mut line);
+                            line = quote! { #line.unwrap_or_default() }
                         }
                     }
+                } else if is_associated_gbuilder {
+                    line = quote! { #line? }
                 } else {
-                    quote! { .ok_or("The field '".to_string() + #field_name + "' should be set")? }
-                        .to_tokens(&mut line);
+                    let err_msg = format!("The field '{field_name}' should be set");
+                    line = quote! { #line.ok_or(#err_msg)? }
                 }
 
                 line
@@ -297,12 +329,14 @@ impl Parse for StructInfo {
 struct FieldInfo {
     hidden: bool,
     default: Option<DefaultAssignment>,
+    use_gbuilder: Option<syn::Path>,
 }
 
 impl Parse for FieldInfo {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut hidden = false;
         let mut default = None;
+        let mut use_gbuilder = None;
 
         loop {
             let ident = input.parse::<syn::Ident>()?;
@@ -318,6 +352,11 @@ impl Parse for FieldInfo {
                         default = Some(DefaultAssignment::DefaultCall)
                     }
                 }
+                "use_gbuilder" => {
+                    let content;
+                    let _paren = parenthesized!(content in input);
+                    use_gbuilder = Some(content.parse()?);
+                }
                 _ => return Err(syn::Error::new(ident.span(), "Unknown attribute")),
             }
 
@@ -328,6 +367,10 @@ impl Parse for FieldInfo {
             }
         }
 
-        Ok(Self { default, hidden })
+        Ok(Self {
+            default,
+            hidden,
+            use_gbuilder,
+        })
     }
 }

--- a/crates/render/src/text.rs
+++ b/crates/render/src/text.rs
@@ -221,6 +221,10 @@ impl TextRect {
             if self.current_paragraph.is_empty() {
                 self.current_paragraph = self.paragraphs.pop_front().unwrap_or_default();
                 paragraph_num += 1;
+
+                if self.current_paragraph.is_empty() {
+                    break;
+                }
             }
         }
 

--- a/crates/render/src/widget/flex_container.rs
+++ b/crates/render/src/widget/flex_container.rs
@@ -13,7 +13,7 @@ use super::{CompileState, Draw, Widget, WidgetConfiguration};
 
 #[derive(macros::GenericBuilder, derive_builder::Builder, Clone)]
 #[builder(pattern = "owned")]
-#[gbuilder(name(GBuilderFlexContainer))]
+#[gbuilder(name(GBuilderFlexContainer), derive(Clone))]
 pub struct FlexContainer {
     #[builder(private, setter(skip))]
     #[gbuilder(hidden, default(None))]
@@ -252,7 +252,7 @@ impl Draw for FlexContainer {
 }
 
 #[derive(macros::GenericBuilder, Debug, Default, Clone)]
-#[gbuilder(name(GBuilderAlignment))]
+#[gbuilder(name(GBuilderAlignment), derive(Clone))]
 pub struct Alignment {
     pub horizontal: Position,
     pub vertical: Position,

--- a/crates/render/src/widget/image.rs
+++ b/crates/render/src/widget/image.rs
@@ -1,4 +1,4 @@
-use config::display::ImageProperty;
+use config::display::{GBuilderImageProperty, ImageProperty};
 use log::warn;
 
 use crate::{
@@ -20,7 +20,7 @@ pub struct WImage {
     #[gbuilder(hidden, default(0))]
     height: usize,
 
-    #[gbuilder(default)]
+    #[gbuilder(use_gbuilder(GBuilderImageProperty), default)]
     property: ImageProperty,
 }
 

--- a/crates/render/src/widget/image.rs
+++ b/crates/render/src/widget/image.rs
@@ -10,7 +10,7 @@ use crate::{
 use super::{CompileState, Draw, WidgetConfiguration};
 
 #[derive(macros::GenericBuilder, Clone)]
-#[gbuilder(name(GBuilderWImage))]
+#[gbuilder(name(GBuilderWImage), derive(Clone))]
 pub struct WImage {
     #[gbuilder(hidden, default(Image::Unknown))]
     content: Image,

--- a/crates/render/src/widget/text.rs
+++ b/crates/render/src/widget/text.rs
@@ -34,6 +34,16 @@ impl Clone for WText {
     }
 }
 
+impl Clone for GBuilderWText {
+    fn clone(&self) -> Self {
+        Self {
+            kind: self.kind.as_ref().cloned(),
+            content: None,
+            property: self.property.as_ref().cloned(),
+        }
+    }
+}
+
 #[derive(Clone, derive_more::Display)]
 pub enum WTextKind {
     #[display("title")]

--- a/crates/render/src/widget/text.rs
+++ b/crates/render/src/widget/text.rs
@@ -1,4 +1,4 @@
-use config::text::TextProperty;
+use config::text::{GBuilderTextProperty, TextProperty};
 use dbus::text::Text;
 use log::warn;
 use shared::{error::ConversionError, value::TryFromValue};
@@ -19,7 +19,7 @@ pub struct WText {
     #[gbuilder(hidden, default(None))]
     content: Option<TextRect>,
 
-    #[gbuilder(default)]
+    #[gbuilder(use_gbuilder(GBuilderTextProperty), default)]
     property: TextProperty,
 }
 
@@ -39,7 +39,7 @@ impl Clone for GBuilderWText {
         Self {
             kind: self.kind.as_ref().cloned(),
             content: None,
-            property: self.property.as_ref().cloned(),
+            property: self.property.clone(),
         }
     }
 }

--- a/crates/shared/src/error.rs
+++ b/crates/shared/src/error.rs
@@ -1,7 +1,9 @@
+use crate::value::Value;
+
 #[derive(Debug, derive_more::Display)]
 pub enum ConversionError {
     #[display("The '{field_name}' field is unknown")]
-    UnknownField { field_name: String },
+    UnknownField { field_name: String, value: Value },
     #[display("Provided invalid value. Expected [{expected}], but given [{actual}]")]
     InvalidValue {
         expected: &'static str,

--- a/crates/shared/src/value.rs
+++ b/crates/shared/src/value.rs
@@ -4,7 +4,7 @@ use crate::error::ConversionError;
 pub enum Value {
     UInt(usize),
     String(String),
-    Any(Box<dyn std::any::Any>),
+    Any(Box<dyn std::any::Any + Send + Sync>),
 }
 
 pub trait TryFromValue: Sized + 'static {
@@ -29,7 +29,7 @@ pub trait TryDowncast {
     fn try_downcast<T: 'static>(self) -> Result<T, ConversionError>;
 }
 
-impl TryDowncast for Box<dyn std::any::Any> {
+impl TryDowncast for Box<dyn std::any::Any + Send + Sync> {
     fn try_downcast<T: 'static>(self) -> Result<T, ConversionError> {
         Ok(*self
             .downcast()
@@ -51,7 +51,7 @@ macro_rules! impl_from_for_value {
 
 impl_from_for_value!(usize => Value::UInt);
 impl_from_for_value!(String => Value::String);
-impl_from_for_value!(Box<dyn std::any::Any> => Value::Any);
+impl_from_for_value!(Box<dyn std::any::Any + Send + Sync> => Value::Any);
 
 impl TryFromValue for usize {
     fn try_from_uint(value: usize) -> Result<Self, ConversionError> {


### PR DESCRIPTION
### Motivation

To avoid any duplication of declarations, need to introduce `alias` keyword for custom layout. It will make the declaration more clean than earlier, also using simple words will simplify understanding the meaning of layout.

#### Related issues

Closes #75 

#### Changes

- Added `derive` for `GenericBuilder`.
- Added safe check in text-compile because the empty lines will adds until available space won't remains.
- Implemented `alias` keyword for custom layout definition.
- Extended `GenericBuilder` by adding associated builders using macro attribute `use_gbuilder` which should help conversion of custom layout into widgets.

#### Syntax of aliases

Alias is like a variable but it stores metadata of Widget or Type Value. The metadata are reusable and overrideable if needed. All of aliases should be defined before main Widget. Here's an example:

```noti
alias Center = Alignment(horizontal = center, vertical = center)
alias CenteredText = Text(justification = center)
alias ItalicCenteredText = CenteredText(style = italic)

alias Title = ItalicCenteredText(kind = title)
alias Body = Text(kind = body, justification = left)

alias Row = FlexContainer(direction = horizontal)
alias Column = FlexContainer(direction = vertical)

Row(
  alignment = Center(),
) {
  Image()
  Column(
    alignment = Center(vertical = start), // We can override the Center alias
  ) {
    Title(font_size = 22)
    Body(font_size = 18)
  }
}
```

#### Addition

With it also updated tree-sitter parser at noti-rs/tree-sitter-noti@783911eb404516971227e07ed87a0d5d36d17f0f.
Updated NeoVim plugin noti.nvim: noti-rs/noti.nvim@cfe3099273f3b1200b5e8a3f5a24030caacb674c.