### PR TITLE
feat: extend gbuilder by aliases and constructor

### DIFF
--- a/crates/config/src/spacing.rs
+++ b/crates/config/src/spacing.rs
@@ -9,7 +9,7 @@ use serde::{de::Visitor, Deserialize};
 use shared::value::TryFromValue;
 
 #[derive(GenericBuilder, Debug, Default, Clone)]
-#[gbuilder(name(GBuilderSpacing), derive(Clone))]
+#[gbuilder(name(GBuilderSpacing), derive(Clone), constructor)]
 pub struct Spacing {
     #[gbuilder(default(0), aliases(vertical, all))]
     top: u8,

--- a/crates/config/src/spacing.rs
+++ b/crates/config/src/spacing.rs
@@ -11,16 +11,16 @@ use shared::value::TryFromValue;
 #[derive(GenericBuilder, Debug, Default, Clone)]
 #[gbuilder(name(GBuilderSpacing), derive(Clone))]
 pub struct Spacing {
-    #[gbuilder(default(0))]
+    #[gbuilder(default(0), aliases(vertical, all))]
     top: u8,
 
-    #[gbuilder(default(0))]
+    #[gbuilder(default(0), aliases(horizontal, all))]
     right: u8,
 
-    #[gbuilder(default(0))]
+    #[gbuilder(default(0), aliases(vertical, all))]
     bottom: u8,
 
-    #[gbuilder(default(0))]
+    #[gbuilder(default(0), aliases(horizontal, all))]
     left: u8,
 }
 

--- a/crates/filetype/src/layout.pest
+++ b/crates/filetype/src/layout.pest
@@ -49,7 +49,7 @@ PropertyValue = { TypeValue | UInt | Literal }
 
 TypeValue = {
   Identifier ~ OpeningParenthesis
-    ~ Properties?
+    ~ (Properties | PropertyValue)?
   ~ ClosingParenthesis }
 
 Literal = ${ Hashtag? ~ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_"  | "-")* }

--- a/crates/macros/src/config_property.rs
+++ b/crates/macros/src/config_property.rs
@@ -7,7 +7,8 @@ use syn::{
 
 use crate::{
     general::{
-        field_name, wrap_by_option, AttributeInfo, DefaultAssignment, DeriveInfo, Structure,
+        field_name, wrap_by_option, AttributeInfo, DefaultAssignment, DeriveInfo, ExpectIdent,
+        Structure,
     },
     propagate_err,
 };
@@ -190,17 +191,14 @@ impl Structure {
         &self,
         attribute_info: &AttributeInfo<StructInfo, FieldInfo>,
     ) -> proc_macro2::TokenStream {
-        let field_idents: Punctuated<&syn::Ident, Token![,]> = self
-            .fields
-            .iter()
-            .map(|field| field.ident.as_ref().expect("Must be a name field!"))
-            .collect();
+        let field_idents: Punctuated<&syn::Ident, Token![,]> =
+            self.fields.iter().map(ExpectIdent::expect_ident).collect();
 
         let init_members: Punctuated<proc_macro2::TokenStream, Token![,]> = self
             .fields
             .iter()
             .map(|field| {
-                let ident = field.ident.as_ref().expect("Must be a named field");
+                let ident = field.expect_ident();
                 let mut line = quote! { #ident: #ident };
 
                 if attribute_info.is_mergeable_field(field)
@@ -237,7 +235,7 @@ impl Structure {
             .fields
             .iter()
             .flat_map(|field| {
-                let field_ident = field.ident.as_ref().expect("Fields should be named");
+                let field_ident = field.expect_ident();
                 attribute_info
                     .fields_info
                     .get(&field_name(field))
@@ -266,18 +264,15 @@ impl Structure {
         target_type: &syn::Ident,
         attribute_info: &AttributeInfo<StructInfo, FieldInfo>,
     ) -> proc_macro2::TokenStream {
-        let field_idents: Punctuated<&syn::Ident, Token![,]> = self
-            .fields
-            .iter()
-            .map(|field| field.ident.as_ref().expect("Must be a name field!"))
-            .collect();
+        let field_idents: Punctuated<&syn::Ident, Token![,]> =
+            self.fields.iter().map(ExpectIdent::expect_ident).collect();
 
         let init_members: Punctuated<proc_macro2::TokenStream, Token![,]> = self
             .fields
             .iter()
             .filter(|field| !attribute_info.is_temporary_field(field))
             .map(|field| {
-                let ident = field.ident.as_ref().expect("Must be a named field");
+                let ident = field.expect_ident();
                 let mut line = quote! { #ident: #ident };
 
                 if let Some(field_info) = attribute_info.fields_info.get(&field_name(field)) {

--- a/crates/macros/src/general.rs
+++ b/crates/macros/src/general.rs
@@ -121,11 +121,7 @@ fn matches(attribute: &syn::Attribute, attribute_name: &str) -> bool {
     false
 }
 pub(crate) fn field_name(field: &syn::Field) -> String {
-    field
-        .ident
-        .as_ref()
-        .expect("Must be a named field")
-        .to_string()
+    field.expect_ident().to_string()
 }
 
 pub(crate) enum DefaultAssignment {
@@ -181,6 +177,16 @@ impl ToTokens for DeriveInfo {
             self.paren
                 .surround(tokens, |tokens| self.traits.to_tokens(tokens));
         });
+    }
+}
+
+pub(crate) trait ExpectIdent {
+    fn expect_ident(&self) -> &syn::Ident;
+}
+
+impl ExpectIdent for syn::Field {
+    fn expect_ident(&self) -> &syn::Ident {
+        self.ident.as_ref().expect("Fields should be named!")
     }
 }
 

--- a/crates/macros/tests/generic_builder.rs
+++ b/crates/macros/tests/generic_builder.rs
@@ -1,5 +1,34 @@
 use shared::value::{TryFromValue, Value};
 
+#[derive(macros::GenericBuilder, PartialEq, Debug)]
+#[gbuilder(name(GBuilderHomogeneousStruct), constructor)]
+#[allow(unused)]
+struct HomogeneousStruct {
+    field1: usize,
+    field2: usize,
+    field3: usize,
+    field4: usize,
+    field5: usize,
+}
+
+#[test]
+fn homogeneous_struct() {
+    let mut gbuilder = GBuilderHomogeneousStruct::new();
+    gbuilder.constructor(Value::UInt(5)).unwrap();
+    let result = gbuilder.try_build().unwrap();
+
+    assert_eq!(
+        result,
+        HomogeneousStruct {
+            field1: 5,
+            field2: 5,
+            field3: 5,
+            field4: 5,
+            field5: 5
+        }
+    )
+}
+
 #[derive(macros::GenericBuilder, Eq, PartialEq, Debug)]
 #[gbuilder(name(GBuilderTest))]
 struct Test {

--- a/crates/macros/tests/generic_builder.rs
+++ b/crates/macros/tests/generic_builder.rs
@@ -3,27 +3,20 @@ use shared::value::{TryFromValue, Value};
 #[derive(macros::GenericBuilder, Eq, PartialEq, Debug)]
 #[gbuilder(name(GBuilderTest))]
 struct Test {
+    #[gbuilder(aliases(field4))]
     field1: usize,
+    #[gbuilder(aliases(field4), default)]
+    field5: usize,
     field2: String,
     #[gbuilder(hidden, default)]
     field3: Option<u32>,
 }
 
 #[test]
-fn check_availability_of_fields() {
-    let gbuilder = GBuilderTest::new();
-
-    assert!(gbuilder.contains_field("field1"));
-    assert!(gbuilder.contains_field("field2"));
-    assert!(!gbuilder.contains_field("field3"));
-    assert!(!gbuilder.contains_field("field4"));
-}
-
-#[test]
 fn build_struct() -> Result<(), Box<dyn std::error::Error>> {
     let mut gbuilder = GBuilderTest::new();
 
-    gbuilder.set_value("field1", Value::UInt(3))?;
+    gbuilder.set_value("field4", Value::UInt(3))?;
     gbuilder.set_value("field2", Value::String("hell".to_string()))?;
 
     let failure_assignment = gbuilder.set_value("field3", Value::UInt(5));
@@ -31,7 +24,8 @@ fn build_struct() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(
         failure_assignment.err().unwrap().to_string(),
         shared::error::ConversionError::UnknownField {
-            field_name: "field3".to_string()
+            field_name: "field3".to_string(),
+            value: Value::UInt(5),
         }
         .to_string()
     );
@@ -42,6 +36,7 @@ fn build_struct() -> Result<(), Box<dyn std::error::Error>> {
         result,
         Test {
             field1: 3,
+            field5: 3,
             field2: "hell".to_string(),
             field3: None
         }
@@ -57,7 +52,7 @@ struct ComplexStructure {
     field3: InnerStructure,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 enum InnerStructure {
     First,
     Second,

--- a/crates/render/src/widget/flex_container.rs
+++ b/crates/render/src/widget/flex_container.rs
@@ -254,7 +254,10 @@ impl Draw for FlexContainer {
 #[derive(macros::GenericBuilder, Debug, Default, Clone)]
 #[gbuilder(name(GBuilderAlignment), derive(Clone))]
 pub struct Alignment {
+    #[gbuilder(aliases(diagonal))]
     pub horizontal: Position,
+
+    #[gbuilder(aliases(diagonal))]
     pub vertical: Position,
 }
 

--- a/crates/render/src/widget/flex_container.rs
+++ b/crates/render/src/widget/flex_container.rs
@@ -252,7 +252,7 @@ impl Draw for FlexContainer {
 }
 
 #[derive(macros::GenericBuilder, Debug, Default, Clone)]
-#[gbuilder(name(GBuilderAlignment), derive(Clone))]
+#[gbuilder(name(GBuilderAlignment), derive(Clone), constructor)]
 pub struct Alignment {
     #[gbuilder(aliases(diagonal))]
     pub horizontal: Position,

--- a/crates/shared/src/error.rs
+++ b/crates/shared/src/error.rs
@@ -4,6 +4,8 @@ use crate::value::Value;
 pub enum ConversionError {
     #[display("The '{field_name}' field is unknown")]
     UnknownField { field_name: String, value: Value },
+    #[display("Unsupported constructor")]
+    UnsupportedConstructor,
     #[display("Provided invalid value. Expected [{expected}], but given [{actual}]")]
     InvalidValue {
         expected: &'static str,


### PR DESCRIPTION
### Motivation

The syntax `Spacing(top = 10, bottom = 10, left = 5, right = 5)` is annoying to declare because or repeating and it's also applicable for `Spacing(top = 5, bottom = 5, left = 5, right = 5)`. Therefore, need to something that should help write less information but achieve the same result.

#### Changes

- The `Value` enum type is now extended by availability to `clone`. It's optional but urgent for assignment the same value for different fields. Of course, for single field the `clone` characteristic will not be used, so don't worry about it.
- Introduced the `alias` of field. Some fields can have the same aliases and it means that for this alias value will assigned for these fields.
- Introduced the `constructor` syntax. If the struct is homogeneous (have the same types of all fields), it can possibility to have a constructor which consumes single value and assigns to all fields.

#### New syntax

The old syntax remains as is. That's why the PR is **extension**.

Currently only `Spacing` and `Alignment` have simplifications:

- Aliases:
  - For `Spacing` introduced new `horizontal`, `vertical` and `all` aliases. The `horizontal` is alias of `top` and `bottom` both, `vertical` - `left` and `right` both, `all` - `top`, `bottom`, `left` and `right` together (why not?).
  - For `Alignment` introduced new `diagonal` alias of `horizontal` and `vertial` both.
- Constructors:
  - For `Spacing` there is a constructor that consumes `UInt` value and assigns to all directions (behaves like `all` alias).
  - For `Alignment` there is a constructor that consumer `Literal` value and assigns to all fields (behaves like `diagonal` alias).

**Example of usage**:

```noti
alias Center = Alignment(diagonal = center)
// or
alias Center = Alignment(center)
// It's the same value

alias OnlyVerticalSpacing = Spacing(vertical = 10) // like Spacing(top = 10, bottom = 10)
alias OnlyHorizontalSpacing = Spacing(horizontal = 20) // like Spacing(left = 20, right = 20)

alias AllDirectionalSpacing = Spacing(all = 15)
// or
alias AllDirectionalSpacing = Spacing(15)
// It's the same value
```

#### What about other types?

Currently there's not so much helpful types to configure layout for which is need to shorthand. But in future might be a type that is homogeneous or some fields are homogeneous and have same semantic, and for these types this shorthand will be applied.