### PR TITLE
fix: use libc allocator for fonts and add math font fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
+ "ttf-parser 0.24.1",
 ]
 
 [[package]]
@@ -1393,9 +1393,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1713,7 +1713,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.24.1",
 ]
 
 [[package]]
@@ -2106,12 +2106,12 @@ dependencies = [
  "freedesktop-icons",
  "image",
  "itertools 0.13.0",
+ "libc",
  "log",
  "macros",
- "owned_ttf_parser",
- "rayon",
  "resvg",
  "shared",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -2192,7 +2192,7 @@ dependencies = [
  "core_maths",
  "log",
  "smallvec",
- "ttf-parser",
+ "ttf-parser 0.24.1",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -2714,6 +2714,12 @@ checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
 dependencies = [
  "core_maths",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "typenum"

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -16,9 +16,9 @@ derive_more.workspace = true
 
 derive_builder = "0.20.0"
 ab_glyph = "0.2.28"
-owned_ttf_parser = "0.24.0"
-rayon = "1.10.0"
 resvg = "0.43.0"
 image = "0.25.2"
 itertools = "0.13.0"
 freedesktop-icons = "0.2.6"
+libc = "0.2.169"
+ttf-parser = "0.25.1"

--- a/crates/render/src/image.rs
+++ b/crates/render/src/image.rs
@@ -1,5 +1,5 @@
 use log::{debug, error, warn};
-use owned_ttf_parser::{RasterGlyphImage, RasterImageFormat};
+use ttf_parser::{RasterGlyphImage, RasterImageFormat};
 
 use config::display::{ImageProperty, ResizingMethod};
 use dbus::image::ImageData;


### PR DESCRIPTION
### Motivation

I found that the Rust allocator is not good for large fonts (or for large data). I don't know why, but the allocator doesn't deallocate the memory in moment because it will be helpful for other parts of application. I call it "reusing".

And as I said, it is bad for large data because after its drop the small parts will use the allocated memory and it won't be enough for next large data. Because of this new allocation will happens. The memory usage will growth more and more. For instance, the `FontCollection` struct drops and new `FontCollections` creates when an user changes the font name in config file. The other font file will have different size. Then when the user decides to switch back to old font name, the owned size is not matches (may be larger than available). So it will cause an additional memory allocation.

With it I also found that math diacritic (like Fraktur) not displays because the math font is separated from general font.

#### Changes

- Implemented `Buffer<T>` container for usage of `libc` allocations.
- With new container the requirement of `OwnedFace` is not necessary, so I drop it by replacing to `Face<'_>`.
- Added `NotoSansMath` font as fallback for math diacritics.

#### Safety

I'm sure that the code is safe because the unsafe operations wraps by `Buffer<T>` container. The deallocation happens in `Buffer<T>`s drop. So it's code is safe.

> [!NOTE]
> Also I should mention that the `Buffer<T>` also provides method `.as_slice()` which returns the `&'static [T]` slice. The code must be safe IF the caller WON'T USE the slice AFTER drop. 