### PR TITLE
chore(cargo): override release profile to focus on min size of binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,16 @@ authors = [ "noti-rs" ]
 version = "0.1.0"
 edition = "2021"
 
+# Focus on min size of bin
+[profile.release]
+lto = true
+strip = true
+opt-level = "z"
+codegen-units = 1
+panic = "abort"
+debug = "none"
+debug-assertions = false
+
 [[bin]]
 path = "crates/app/main.rs"
 name = "noti"


### PR DESCRIPTION
### Motivation

Reduce the binary size from 14mb to 6.1 in average without breaking.