### PR TITLE
refactor: replace debug prints via {:?} to normal prints

### DIFF
--- a/crates/backend/src/managers/window_manager/cache.rs
+++ b/crates/backend/src/managers/window_manager/cache.rs
@@ -21,7 +21,10 @@ impl CachedLayout {
         match filetype::parse_layout(path) {
             Ok(widget) => Some(widget),
             Err(err) => {
-                warn!("The layout by path {path:?} is not valid. Error: {err}");
+                warn!(
+                    "The layout by path {path} is not valid. Error: {err}",
+                    path = path.display()
+                );
                 None
             }
         }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -54,9 +54,15 @@ impl NotiClient<'_> {
             \tapp_icon - {icon},\n\
             \tsummary - {summary},\n\
             \tbody - {body},\n\
-            \tactions - {actions:?},\n\
-            \thints - {new_hints:?},\n\
-            \ttimeout - {timeout}"
+            \tactions - [{actions}],\n\
+            \thints - {{ {new_hints} }},\n\
+            \ttimeout - {timeout}",
+            actions = actions.join(", "),
+            new_hints = new_hints
+                .iter()
+                .map(|(k, v)| k.to_string() + ": " + &v.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
         );
 
         let notification_id = self

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -240,7 +240,10 @@ impl TomlConfig {
     ) -> Option<ParsedTomlConfig> {
         let config_path = PathBuf::from(path?);
         if !config_tree_path.insert(config_path.clone()) {
-            error!("Found circular imports! Check the config file {config_path:?}");
+            error!(
+                "Found circular imports! Check the config file {config_path}",
+                config_path = config_path.display()
+            );
             return None;
         }
 
@@ -389,7 +392,10 @@ fn expand_path(value: String, path_prefix: &Path) -> Vec<PathBuf> {
     }
 
     let Some(expanded_path_str) = expanded_path.to_str() else {
-        error!("Path {expanded_path:?} is not UTF-8 valid!");
+        error!(
+            "Path {expanded_path} is not UTF-8 valid!",
+            expanded_path = expanded_path.display()
+        );
         return vec![];
     };
 
@@ -399,8 +405,8 @@ fn expand_path(value: String, path_prefix: &Path) -> Vec<PathBuf> {
             .inspect(|entry| {
                 if let Err(err) = entry {
                     warn!(
-                        "Failed to read config file at {:?}. Error: {}",
-                        err.path(),
+                        "Failed to read config file at {}. Error: {}",
+                        err.path().display(),
                         err.error()
                     );
                 }

--- a/crates/dbus/src/text.rs
+++ b/crates/dbus/src/text.rs
@@ -227,10 +227,11 @@ impl<'a> Parser<'a> {
         } else {
             let range = closing_tag.byte_pos_begin..closing_tag.byte_pos_end;
             warn!(
-                "Unexpected closing tag {} at {:?} in text: {}",
-                &self.input[range.clone()],
-                range,
-                self.input
+                "Unexpected closing tag {tag} at {start}..{end} in text: {input}",
+                tag = &self.input[range.clone()],
+                start = range.start,
+                end = range.end,
+                input = self.input
             );
         }
     }

--- a/crates/shared/src/file_watcher.rs
+++ b/crates/shared/src/file_watcher.rs
@@ -30,7 +30,14 @@ impl FilesWatcher {
         let inotify = Inotify::init()?;
 
         let paths: Vec<FilePath> = paths.into_iter().map(From::from).collect();
-        debug!("Watcher: Received paths - {paths:?}");
+        debug!(
+            "Watcher: Received paths - {paths}",
+            paths = paths
+                .iter()
+                .map(|p| p.path_buf.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
 
         let config_wd = paths
             .iter()
@@ -170,7 +177,10 @@ impl InotifySpecialization for Inotify {
             .watches()
             .add(file_path.as_path(), DEFAULT_MASKS)
             .unwrap_or_else(|_| {
-                panic!("Failed to create watch descriptor for config path {file_path:?}")
+                panic!(
+                    "Failed to create watch descriptor for config path {file_path}",
+                    file_path = file_path.path_buf.display()
+                )
             });
 
         FileWd::from_wd(new_wd, file_path.path_buf.clone())


### PR DESCRIPTION
Since we provide a way to compile code into minimized binary size, the debug prints will be stripped from binary. Therefore we need to replace them to normal prints with extra steps that won't be costly at all.