### PR TITLE
More descriptive compile errors

### DIFF
--- a/crates/render/src/widget.rs
+++ b/crates/render/src/widget.rs
@@ -65,10 +65,12 @@ impl Widget {
             Widget::Unknown => CompileState::Success,
         };
 
-        if let CompileState::Failure = state {
+        if let CompileState::Failure { reason } = state {
             warn!(
-                "A {wtype} widget is not compiled due errors!",
-                wtype = self.get_type()
+                "A {wtype} widget failed to compile: {reason}. notification_id={id}, app_name='{app_name}'",
+                wtype = self.get_type(),
+                id = configuration.notification.id,
+                app_name = configuration.notification.app_name
             );
             *self = Widget::Unknown;
         }
@@ -120,7 +122,7 @@ impl Draw for Widget {
 
 pub enum CompileState {
     Success,
-    Failure,
+    Failure { reason: String },
 }
 
 pub struct WidgetConfiguration<'a> {

--- a/crates/render/src/widget/image.rs
+++ b/crates/render/src/widget/image.rs
@@ -120,13 +120,28 @@ impl WImage {
                 \nAvailable space: width={}, height={}.",
                 self.width, self.height, rect_size.width, rect_size.height
             );
-            return CompileState::Failure;
+            return CompileState::Failure {
+                reason: format!(
+                    "image does not fit available space (image: {image_width}x{image_height}, available: {available_width}x{available_height})",
+                    image_width = self.width,
+                    image_height = self.height,
+                    available_width = rect_size.width,
+                    available_height = rect_size.height,
+                ),
+            };
         }
 
         if self.content.is_exists() {
             CompileState::Success
         } else {
-            CompileState::Failure
+            CompileState::Failure {
+                reason: format!(
+                    "image content unavailable (app_icon='{}', image_path_present={}, image_data_present={})",
+                    notification.app_icon,
+                    notification.hints.image_path.is_some(),
+                    notification.hints.image_data.is_some(),
+                ),
+            }
         }
     }
 

--- a/crates/render/src/widget/text.rs
+++ b/crates/render/src/widget/text.rs
@@ -131,7 +131,9 @@ impl WText {
         let (text, attributes) = notification_content.as_str_with_attributes();
         if text.trim().is_empty() {
             warn!("The text with kind {} is blank", self.kind);
-            return CompileState::Failure;
+            return CompileState::Failure {
+                reason: format!("{kind} text content is blank", kind = self.kind),
+            };
         }
 
         layout.set_text(text);
@@ -145,7 +147,14 @@ impl WText {
                 Available space: width={}, height={}.",
                 self.kind, rect_size.width, rect_size.height
             );
-            CompileState::Failure
+            CompileState::Failure {
+                reason: format!(
+                    "{kind} text does not fit available space (computed: {computed_width}x{computed_height}, available: {available_width}x{available_height})",
+                    kind = self.kind,
+                    available_width = rect_size.width,
+                    available_height = rect_size.height,
+                ),
+            }
         } else {
             self.inner_size = rect_size;
             self.layout = Some(layout);


### PR DESCRIPTION
Includes a `reason` string to `CompileState::Failure`, so widgets that fail to compile can bubble up some more details about the problem.